### PR TITLE
ObjectsTable: Add onSelectionChange

### DIFF
--- a/src/objects-table/ObjectsTable.js
+++ b/src/objects-table/ObjectsTable.js
@@ -141,6 +141,10 @@ class ObjectsTable extends React.Component {
         this.getObjects({ clearPage: false });
     }
 
+    notifySelectionChange = () => {
+        this.props.onSelectionChange(this.state.selection);
+    };
+
     async getObjects({ clearPage = true } = {}) {
         const { d2, pageSize, list, customFilters } = this.props;
         const { page, sorting, searchValue } = this.state;
@@ -155,8 +159,7 @@ class ObjectsTable extends React.Component {
             dataRows: objects,
             page: newPage,
             selection: [],
-        });
-        this.props.onSelectionChange([]);
+        }, this.notifySelectionChange);
     }
 
     onSearchChange = value => {
@@ -177,15 +180,13 @@ class ObjectsTable extends React.Component {
         const deletedIds = _.remove(selection, id => id === obj.id);
         if (deletedIds.length === 0) selection.push(obj.id);
 
-        this.setState({ selection });
-        this.props.onSelectionChange(selection);
+        this.setState({ selection }, this.notifySelectionChange);
     }
 
     onSelectAllToggle = selectedHeaderChecked => {
         const selection = selectedHeaderChecked ? [] : this.state.dataRows.map(dr => dr.id);
 
-        this.setState({ selection });
-        this.props.onSelectionChange(selection);
+        this.setState({ selection }, this.notifySelectionChange);
     };
 
     onActiveRowsChange = objs => {

--- a/src/objects-table/ObjectsTable.js
+++ b/src/objects-table/ObjectsTable.js
@@ -142,7 +142,7 @@ class ObjectsTable extends React.Component {
     }
 
     notifySelectionChange = () => {
-        this.props.onSelectionChange(this.state.selection);
+        this.props.onSelectionChange(_.cloneDeep(this.state.selection));
     };
 
     async getObjects({ clearPage = true } = {}) {

--- a/src/objects-table/ObjectsTable.js
+++ b/src/objects-table/ObjectsTable.js
@@ -142,7 +142,7 @@ class ObjectsTable extends React.Component {
     }
 
     notifySelectionChange = () => {
-        this.props.onSelectionChange(_.cloneDeep(this.state.selection));
+        this.props.onSelectionChange(_.clone(this.state.selection));
     };
 
     async getObjects({ clearPage = true } = {}) {

--- a/src/objects-table/ObjectsTable.js
+++ b/src/objects-table/ObjectsTable.js
@@ -179,7 +179,7 @@ class ObjectsTable extends React.Component {
         ev.preventDefault();
         ev.stopPropagation();
 
-        const { selection } = this.state;
+        const selection = new Set(this.state.selection);
         const found = selection.delete(obj.id);
         if (!found) selection.add(obj.id);
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #14 

### 💻 Status

- Ready to merge

- Tested with metadata-sync

### :memo: Implementation

- Selection is still in a controlled state

- Objects Table notifies App with new selection with onSelectionChange prop

- Selection is deep cloned so the internal reference is lost outside ObjectsTable

### 🎨 Screenshots

![image](https://user-images.githubusercontent.com/2181866/54109062-e1677d00-43dd-11e9-8ef2-7ccd194c1893.png)

### 📓 Test example

**Metadata Synchronization**

```js
--- a/src/components/sync-configurator/BaseSyncConfigurator.jsx
+++ b/src/components/sync-configurator/BaseSyncConfigurator.jsx
@@ -40,6 +40,7 @@ export default class BaseSyncConfigurator extends React.Component {
                     initialSorting={model.getInitialSorting()}
                     actions={this.actions}
                     list={list}
+                    onSelectionChange={(selection) => console.log({selection})}
                 />
             </div>
```