### PR TITLE
Create datePickerFilter to use with ObjectsTable

### DIFF
--- a/src/date-table-filter/DateTableFilter.jsx
+++ b/src/date-table-filter/DateTableFilter.jsx
@@ -1,0 +1,92 @@
+import React, { PureComponent } from "react";
+import PropTypes from "prop-types";
+import moment from "moment";
+import MomentUtils from "@date-io/moment";
+
+import { MuiPickersUtilsProvider, DatePicker as MuiDatePicker } from "material-ui-pickers";
+import { MuiThemeProvider, createMuiTheme } from "@material-ui/core";
+import { withStyles } from "@material-ui/core/styles";
+import cyan from "@material-ui/core/colors/cyan";
+
+const grey = "#aaaaaa";
+
+const styles = () => ({
+    fieldContainer: {
+        display: "inline-block",
+        marginLeft: 10,
+    },
+});
+
+const materialTheme = createMuiTheme({
+    typography: {
+        useNextVariants: true,
+    },
+    overrides: {
+        MuiFormControl: {
+            marginNormal: {
+                marginTop: 8,
+                marginBottom: 0,
+            },
+        },
+        MuiFormLabel: {
+            root: {
+                color: grey,
+                "&$focused": {
+                    color: cyan["500"],
+                },
+            },
+        },
+        MuiInput: {
+            input: {
+                color: "#565656",
+            },
+            underline: {
+                "&&&&:hover:before": {
+                    borderBottom: `1px solid #e0e0e0`,
+                },
+                "&:hover:not($disabled):before": {
+                    borderBottom: `1px solid ${grey}`,
+                },
+                "&:after": {
+                    borderBottom: `2px solid ${cyan["500"]}`,
+                },
+                "&:before": {
+                    borderBottom: `1px solid #e0e0e0`,
+                },
+            },
+        },
+    },
+});
+
+class DateTableFilter extends PureComponent {
+    static propTypes = {
+        placeholder: PropTypes.string,
+        value: PropTypes.object,
+        onChange: PropTypes.func.isRequired,
+    };
+
+    render() {
+        const { placeholder, value, onChange, classes } = this.props;
+        const format = moment.localeData().longDateFormat("L");
+
+        return (
+            <div className={classes.fieldContainer}>
+                <MuiThemeProvider theme={materialTheme}>
+                    <MuiPickersUtilsProvider utils={MomentUtils}>
+                        <MuiDatePicker
+                            margin="normal"
+                            placeholder={placeholder}
+                            value={value}
+                            format={format}
+                            onChange={onChange}
+                            clearable={true}
+                            autoOk={true}
+                        />
+                    </MuiPickersUtilsProvider>
+                </MuiThemeProvider>
+            </div>
+        );
+    }
+}
+
+export default withStyles(styles)(DateTableFilter);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import OrgUnitsSelector from "./org-units-selector/OrgUnitsSelector";
 import { withSnackbar } from "./snackbar";
 import SnackbarProvider from "./snackbar/SnackbarProvider";
 import ObjectsTable from "./objects-table/ObjectsTable";
+import DateTableFilter from "./date-table-filter/DateTableFilter";
 
 import "./locales";
 
@@ -20,4 +21,5 @@ export {
     SnackbarProvider,
     withSnackbar,
     ObjectsTable,
+    DateTableFilter,
 };


### PR DESCRIPTION
This is a DatePicker formatted to look good as an ObjectsTable filter. `label` is removed in favor of `placeholder` and styles differ from the DatePicker form field

![image](https://user-images.githubusercontent.com/15323369/55081444-2955f780-50a0-11e9-9e39-8ea8df0d65f5.png)
![image](https://user-images.githubusercontent.com/15323369/55081469-31159c00-50a0-11e9-9f8f-e283f660ac27.png)
