### PR TITLE
MultiSelector: Allow selection to be uncontrolled

### DIFF
--- a/src/multi-selector/MultiSelector.jsx
+++ b/src/multi-selector/MultiSelector.jsx
@@ -23,13 +23,15 @@ class MultiSelector extends React.Component {
     static propTypes = {
         d2: PropTypes.object.isRequired,
         height: PropTypes.number,
-        ordered: PropTypes.bool.isRequired,
+        ordered: PropTypes.bool,
         options: optionsPropType.isRequired,
-        selected: PropTypes.arrayOf(PropTypes.string).isRequired,
+        selected: PropTypes.arrayOf(PropTypes.string),
     };
 
     static defaultProps = {
         height: 300,
+        selected: [],
+        ordered: true,
     };
 
     // Required by <GroupEditor>

--- a/src/multi-selector/MultiSelector.jsx
+++ b/src/multi-selector/MultiSelector.jsx
@@ -56,12 +56,14 @@ class MultiSelector extends React.Component {
         return this.isControlled ? this.props.selected : this.state.selected;
     };
 
-    updateSelected = async updateFn => {
+    updateSelected = updateFn => {
         const oldSelected = this.getSelected();
         const selected = updateFn(oldSelected);
 
         this.setState({ selected });
         this.props.onChange(selected);
+
+        return Promise.resolve();
     };
 
     assignItems = values => {

--- a/src/multi-selector/MultiSelector.jsx
+++ b/src/multi-selector/MultiSelector.jsx
@@ -60,7 +60,7 @@ class MultiSelector extends React.Component {
         const oldSelected = this.getSelected();
         const selected = updateFn(oldSelected);
 
-        this.setState({ selected });
+        if (!this.isControlled) this.setState({ selected });
         this.props.onChange(selected);
 
         return Promise.resolve();

--- a/src/multi-selector/MultiSelector.jsx
+++ b/src/multi-selector/MultiSelector.jsx
@@ -30,6 +30,7 @@ class MultiSelector extends React.Component {
         ordered: PropTypes.bool,
         options: optionsPropType.isRequired,
         selected: PropTypes.arrayOf(PropTypes.string),
+        onChange: PropTypes.func.isRequired,
     };
 
     static defaultProps = {

--- a/src/multi-selector/MultiSelector.jsx
+++ b/src/multi-selector/MultiSelector.jsx
@@ -20,6 +20,10 @@ const optionsPropType = PropTypes.arrayOf(
 );
 
 class MultiSelector extends React.Component {
+    state = {
+        selected: []
+    };
+
     static propTypes = {
         d2: PropTypes.object.isRequired,
         height: PropTypes.number,
@@ -30,7 +34,6 @@ class MultiSelector extends React.Component {
 
     static defaultProps = {
         height: 300,
-        selected: [],
         ordered: true,
     };
 
@@ -45,26 +48,27 @@ class MultiSelector extends React.Component {
         };
     }
 
-    assignItems = values => {
-        const newValues = this.props.selected.concat(values);
-        this.props.onChange(newValues);
-        return Promise.resolve();
+    assignItems = async values => {
+        const selected = this.state.selected.concat(values);
+        this.setState({ selected });
+        this.props.onChange(selected);
     };
 
-    unassignItems = values => {
+    unassignItems = async values => {
         const itemValuesToRemove = new Set(values);
-        const newValues = this.props.selected.filter(value => !itemValuesToRemove.has(value));
-        this.props.onChange(newValues);
-        return Promise.resolve();
+        const selected = this.state.selected.filter(value => !itemValuesToRemove.has(value));
+        this.setState({ selected });
+        this.props.onChange(selected);
     };
 
-    orderChanged = values => {
+    orderChanged = async values => {
         this.props.onChange(values);
-        return Promise.resolve();
     };
 
     render() {
-        const { height, options, selected, classes, ordered } = this.props;
+        const { height, options, classes, ordered } = this.props;
+
+        const selected = this.props.selected ? this.props.selected : this.state.selected;
 
         const itemStore = Store.create();
         const assignedItemStore = Store.create();

--- a/src/multi-selector/MultiSelector.jsx
+++ b/src/multi-selector/MultiSelector.jsx
@@ -56,26 +56,19 @@ class MultiSelector extends React.Component {
         return this.isControlled ? this.props.selected : this.state.selected;
     };
 
-    updateSelected = updateFn => {
-        const selected = this.getSelected();
-        const selectedUpdated = updateFn(selected);
+    updateSelected = async updateFn => {
+        const oldSelected = this.getSelected();
+        const selected = updateFn(oldSelected);
 
-        if (this.isControlled) {
-            this.props.onChange(selectedUpdated);
-        } else {
-            this.setState({ selected: selectedUpdated });
-            this.props.onChange(selectedUpdated);
-        }
-
-        // <GroupEditor> requires the props assign/unassign/orderChange to return a promise
-        return Promise.resolve();
+        this.setState({ selected });
+        this.props.onChange(selected);
     };
 
     assignItems = values => {
         return this.updateSelected(selected => selected.concat(values));
     };
 
-    unassignItems = values => {
+    removeItems = values => {
         const itemValuesToRemove = new Set(values);
         return this.updateSelected(selected =>
             selected.filter(value => !itemValuesToRemove.has(value))
@@ -105,7 +98,7 @@ class MultiSelector extends React.Component {
                     itemStore={itemStore}
                     assignedItemStore={assignedItemStore}
                     onAssignItems={this.assignItems}
-                    onRemoveItems={this.unassignItems}
+                    onRemoveItems={this.removeItems}
                     height={height}
                     {...extraProps}
                 />


### PR DESCRIPTION
### :memo: Implementation

- Make ordered optional and default to true

- Add a uncontrolled state selection

- If selection is overrided from parent through props ignore enter controlled state