### PR TITLE
Fix/confirmation dialog paragraphs

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "build-dev": "yarn build-only --watch --verbose",
         "code-quality": "yarn lint && yarn prettify && yarn test",
         "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
-        "lint": "eslint src src/ --ext .js,.ts,.jsx,.tsx",
+        "lint": "eslint src src/ --ext .js,.jsx",
         "localize": "yarn extract-pot && yarn update-po && yarn localize-update",
         "localize-update": "d2-i18n-generate -n d2-ui-components -p ./i18n/ -o ./src/locales/",
         "update-po": "for pofile in i18n/*.po; do msgmerge --backup=off -U $pofile i18n/en.pot; done",

--- a/src/confirmation-dialog/ConfirmationDialog.jsx
+++ b/src/confirmation-dialog/ConfirmationDialog.jsx
@@ -1,14 +1,7 @@
 import React from "react";
 import i18n from "@dhis2/d2-i18n";
 import PropTypes from "prop-types";
-import {
-    Dialog,
-    DialogTitle,
-    DialogContent,
-    DialogContentText,
-    DialogActions,
-    Button,
-} from "@material-ui/core";
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button } from "@material-ui/core";
 
 class ConfirmationDialog extends React.Component {
     static propTypes = {
@@ -46,7 +39,13 @@ class ConfirmationDialog extends React.Component {
                 <DialogTitle>{title}</DialogTitle>
 
                 <DialogContent>
-                    {description && <DialogContentText>{description.split('\n').map(text => <p>{text}</p>)}</DialogContentText>}
+                    {description && (
+                        <React.Fragment>
+                            {description.split("\n").map((text, idx) => (
+                                <p key={idx}>{text}</p>
+                            ))}
+                        </React.Fragment>
+                    )}
                     {children}
                 </DialogContent>
 


### PR DESCRIPTION
- Remove ts/tsx files from eslint, they raise false positive, leave tsc to take care of linting.
- Component DialogContentText renders a p, so the inner p (from the split description) raised an HTML warning, p cannot be inside a p.
- Add React key to array of p's