### PR TITLE
Fix multiple objects callback handler

### DIFF
--- a/src/data-table/DataTable.jsx
+++ b/src/data-table/DataTable.jsx
@@ -182,7 +182,7 @@ class DataTable extends React.Component {
                 },
                 this.notifyActiveRows
             );
-            this.props.primaryAction(rowSource);
+            this.props.primaryAction([rowSource]);
             return;
         }
 

--- a/src/data-table/MultipleDataTableContextMenu.component.js
+++ b/src/data-table/MultipleDataTableContextMenu.component.js
@@ -76,8 +76,9 @@ class MultipleDataTableContextMenu extends React.Component {
         const fn = _(this.props.actions)
             .keyBy("name")
             .get([action, "fn"]);
-        fn.apply(this.props.actions, this.props.activeItems);
-        this.props.onRequestClose && this.props.onRequestClose();
+
+        fn(this.props.activeItems);
+        if (this.props.onRequestClose) this.props.onRequestClose();
     }
 }
 

--- a/src/objects-table/ObjectsTable.js
+++ b/src/objects-table/ObjectsTable.js
@@ -309,7 +309,11 @@ class ObjectsTable extends React.Component {
                             onColumnSort={this.onColumnSort}
                             contextMenuActions={this.actions.contextActions}
                             contextMenuIcons={this.actions.contextMenuIcons}
-                            primaryAction={this.actions.contextActions[0].fn}
+                            primaryAction={
+                                this.actions.contextActions.length > 0
+                                    ? this.actions.contextActions[0].fn
+                                    : undefined
+                            }
                             isContextActionAllowed={this.isContextActionAllowed}
                             activeRows={activeRows}
                             onActiveRowsChange={this.onActiveRowsChange}

--- a/src/objects-table/actions.js
+++ b/src/objects-table/actions.js
@@ -23,9 +23,9 @@ export function setupActions(actions, onClick) {
     };
 
     const contextActions = actions.map(action => {
-        const handler = data => {
-            const arg = action.multiple && !_.isArray(data) ? [data] : data;
-            onClick(action.name, arg);
+        const handler = objects => {
+            const arg = action.multiple ? objects : objects[0];
+            if (arg) onClick(action.name, arg);
         };
         return { name: action.name, text: action.text, fn: handler };
     });


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #28 

### :memo: Implementation

Multiple selection had a bug. Refactored to use always an array of objects and only at the final callback send a single object if `multiple` option is disabled.