### PR TITLE
Allow hiding default search box from ObjectsTable

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,10 +231,13 @@ const MyObjectsTable = () => (
         pageSize={20}
         initialSorting={["displayName", "asc"]}
         actions={actions}
-        onCreate={true}
+        onButtonClick={() => console.log("Floating button clicked")}
+        buttonLabel={someString || <SomeComponent >}
         list={list} // list(d2, filters, pagination) -> {pager, objects}
         customFiltersComponent={CustomFilters}
         customFilters={{key1: "value1", key2: "value2}}
+        onSelectionChange={objectIds => console.log(objectIds)}
+        hideSearchBox={false}
     />
 );
 ```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "0.0.17",
+    "version": "0.0.18",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/objects-table/ObjectsTable.js
+++ b/src/objects-table/ObjectsTable.js
@@ -21,7 +21,6 @@ import { getFormatter } from "../helpers/d2";
 class ObjectsTable extends React.Component {
     static propTypes = {
         d2: PropTypes.object.isRequired,
-        name: PropTypes.string,
         onButtonClick: PropTypes.func,
         pageSize: PropTypes.number.isRequired,
         model: PropTypes.object.isRequired,

--- a/src/objects-table/ObjectsTable.js
+++ b/src/objects-table/ObjectsTable.js
@@ -67,11 +67,13 @@ class ObjectsTable extends React.Component {
         customFilters: PropTypes.object,
         onSelectionChange: PropTypes.func,
         buttonLabel: PropTypes.node,
+        hideSearchBox: PropTypes.bool,
     };
 
     static defaultProps = {
         onSelectionChange: () => {},
         buttonLabel: null,
+        hideSearchBox: false,
     };
 
     constructor(props) {
@@ -323,6 +325,7 @@ class ObjectsTable extends React.Component {
             model,
             customFiltersComponent,
             buttonLabel,
+            hideSearchBox,
         } = this.props;
         const { dataRows, sorting, selection, isLoading, detailsObject } = this.state;
         const { contextActions, contextMenuIcons } = this.actions;
@@ -360,9 +363,11 @@ class ObjectsTable extends React.Component {
         return (
             <div>
                 <div>
-                    <div style={styles.searchBox}>
-                        <SearchBox onChange={this.onSearchChange} />
-                    </div>
+                    {!hideSearchBox && (
+                        <div style={styles.searchBox}>
+                            <SearchBox onChange={this.onSearchChange} />
+                        </div>
+                    )}
 
                     <CustomFilters />
 

--- a/src/objects-table/ObjectsTable.js
+++ b/src/objects-table/ObjectsTable.js
@@ -22,7 +22,7 @@ class ObjectsTable extends React.Component {
     static propTypes = {
         d2: PropTypes.object.isRequired,
         name: PropTypes.string,
-        onCreate: PropTypes.func,
+        onButtonClick: PropTypes.func,
         pageSize: PropTypes.number.isRequired,
         model: PropTypes.object.isRequired,
         initialSorting: PropTypes.array.isRequired, // [fieldName, "asc" | "desc"]
@@ -319,7 +319,7 @@ class ObjectsTable extends React.Component {
 
     render() {
         const {
-            onCreate,
+            onButtonClick,
             columns,
             detailsFields,
             model,
@@ -435,7 +435,7 @@ class ObjectsTable extends React.Component {
                     ) : null}
                 </div>
 
-                {onCreate && <ListActionBar onClick={onCreate} label={buttonLabel} />}
+                {onButtonClick && <ListActionBar onClick={onButtonClick} label={buttonLabel} />}
             </div>
         );
     }


### PR DESCRIPTION
Allow hiding the search box when the page does not need a string search. Right now we need it for Notifications Page on metadata-sync where we will only host a CustomFilter with a dropdown.

![image](https://user-images.githubusercontent.com/2181866/58498460-6319ac00-817e-11e9-8da9-82b918b2a4d7.png)

