### PR TITLE
Add initial selection to Objects Table

### DIFF
--- a/src/objects-table/ObjectsTable.js
+++ b/src/objects-table/ObjectsTable.js
@@ -65,6 +65,7 @@ class ObjectsTable extends React.Component {
         customFiltersComponent: PropTypes.func,
         customFilters: PropTypes.object,
         onSelectionChange: PropTypes.func,
+        initialSelection: PropTypes.array,
         buttonLabel: PropTypes.node,
         hideSearchBox: PropTypes.bool,
     };
@@ -73,6 +74,7 @@ class ObjectsTable extends React.Component {
         onSelectionChange: () => {},
         buttonLabel: null,
         hideSearchBox: false,
+        initialSelection: []
     };
 
     constructor(props) {
@@ -131,7 +133,7 @@ class ObjectsTable extends React.Component {
             sorting: this.props.initialSorting,
             searchValue: null,
             detailsObject: null,
-            selection: new Set(),
+            selection: new Set(this.props.initialSelection),
             allObjects: new Set(),
         };
     }


### PR DESCRIPTION
This allows to pre-load the Objects Table with selected items.

Use case: We now have an ObjectsTable in a Wizard, on edit (or even pagination) we load the selected items from the stored state.

Example (the elements were selected programmatically by the stored state):

![image](https://user-images.githubusercontent.com/2181866/60246527-23e69400-98bf-11e9-8826-40d78633f6c2.png)
