### PR TITLE
Set a default autoHide only for success messages

### DIFF
--- a/src/snackbar/SnackbarProvider.jsx
+++ b/src/snackbar/SnackbarProvider.jsx
@@ -14,7 +14,12 @@ export default class SnackbarProvider extends Component {
     }
 
     // level : "success" | "info" | "warning" | "error"
-    openSnackbar = (level, message, { autoHideDuration = 2000 } = {}) => {
+    // options : {autoHideDuration: NUMBER}
+    openSnackbar = (level, message, options = {}) => {
+        const defaultAutoHideDuration = level === "success" ? 2000 : 0;
+        const autoHideDuration = options.hasOwnProperty("autoHideDuration")
+            ? options.autoHideDuration
+            : defaultAutoHideDuration;
         this.setState({
             message,
             isOpen: true,

--- a/src/snackbar/SnackbarProvider.jsx
+++ b/src/snackbar/SnackbarProvider.jsx
@@ -16,7 +16,7 @@ export default class SnackbarProvider extends Component {
     // level : "success" | "info" | "warning" | "error"
     // options : {autoHideDuration: NUMBER}
     openSnackbar = (level, message, options = {}) => {
-        const defaultAutoHideDuration = level === "success" ? 2000 : 0;
+        const defaultAutoHideDuration = level === "success" ? 2000 : undefined;
         const autoHideDuration = options.hasOwnProperty("autoHideDuration")
             ? options.autoHideDuration
             : defaultAutoHideDuration;


### PR DESCRIPTION
On success messages it's ok to auto-hide the snackbar messages, but in any other level, the user needs time to read or maybe copy/paste its contents. Now the user will have to dismiss it on non-success messages.