### PR TITLE
Add vertical align to data table

### DIFF
--- a/src/data-table/MultipleDataTableRow.component.js
+++ b/src/data-table/MultipleDataTableRow.component.js
@@ -34,13 +34,13 @@ class MultipleDataTableRow extends React.Component {
             textOverflow: "ellipsis",
             overflow: "hidden",
             whiteSpace: "nowrap",
-            position: "absolute",
             wordBreak: "break-all",
             wordWrap: "break-word",
             top: 0,
             bottom: 0,
             lineHeight: "50px",
             paddingRight: "1rem",
+            verticalAlign: "middle",
         };
 
         const columns = this.props.columns.map((column, index) => {


### PR DESCRIPTION
Vertical alignment is not ideal when working with multiple lines, instead of fixing the position to absolute, force it to the middle of the row.

Before:

![image](https://user-images.githubusercontent.com/2181866/60245887-cdc52100-98bd-11e9-9390-26b6f5f79c58.png)

After:

![image](https://user-images.githubusercontent.com/2181866/60246355-ceaa8280-98be-11e9-8185-7b160275f716.png)
