### PR TITLE
[OrgUnitsSelector] Add props listParams and rootIds

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ const MyOrgUnitsSelector = () => (
         onChange={orgUnitsPaths => console.log("Selected orgUnitPaths", orgUnitsPaths)}
         selected={["/ImspTQPwCqd/O6uvpzGd5pu", "/ImspTQPwCqd/PMa2VCrupOd"]}
         levels={[1, 2]}
+        rootIds={["ImspTQPwCqd"]}
+        listParams={{ maxLevel: 4 }}
     />
 );
 ```

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import _ from "lodash";
 
 import Card from "material-ui/Card/Card";
 import CardText from "material-ui/Card/CardText";
@@ -21,6 +22,8 @@ export default class OrgUnitsSelector extends React.Component {
         onChange: PropTypes.func.isRequired,
         selected: PropTypes.arrayOf(PropTypes.string).isRequired,
         levels: PropTypes.arrayOf(PropTypes.number),
+        rootIds: PropTypes.arrayOf(PropTypes.string),
+        listParams: PropTypes.object,
         controls: PropTypes.shape({
             filterByLevel: PropTypes.bool,
             filterByGroup: PropTypes.bool,
@@ -76,7 +79,7 @@ export default class OrgUnitsSelector extends React.Component {
                       paging: false,
                       fields: "id,displayName",
                   }),
-            getDefaultRoots(props.d2),
+            this.getRoots({}),
         ]).then(([levels, groups, defaultRoots]) => {
             this.setState({
                 roots: defaultRoots,
@@ -84,6 +87,37 @@ export default class OrgUnitsSelector extends React.Component {
                 groups,
             });
         });
+    }
+
+    getRoots({ filter }) {
+        const { d2, listParams, rootIds } = this.props;
+        const pagingOptions = { paging: true, pageSize: 10 };
+        let options;
+
+        if (!filter && !rootIds) {
+            options = { level: 1, paging: false };
+        } else if (!filter && rootIds) {
+            options = { filter: `id:in:[${rootIds.join(",")}]`, paging: false };
+        } else if (filter && !rootIds) {
+            options = { filter, ...pagingOptions };
+        } else if (filter && rootIds) {
+            options = {
+                filter,
+                ...pagingOptions,
+                postFilter: orgUnit => rootIds.some(ouId => orgUnit.path.includes(ouId)),
+            };
+        }
+
+        const listOptions = {
+            paging: false,
+            fields: "id,displayName,path",
+            ...listParams,
+            ..._.omit(options, ["postFilter"]),
+        };
+
+        return d2.models.organisationUnits
+            .list(listOptions)
+            .then(collection => collection.toArray().filter(options.postFilter || _.identity));
     }
 
     getChildContext() {
@@ -133,17 +167,8 @@ export default class OrgUnitsSelector extends React.Component {
     };
 
     filterOrgUnits = async value => {
-        const roots = await (!value
-            ? getDefaultRoots(this.props.d2)
-            : this.props.d2.models.organisationUnits
-                  .list({
-                      paging: true,
-                      pageSize: 10,
-                      fields: "id,displayName,path",
-                      filter: `displayName:ilike:${value}`,
-                  })
-                  .then(collection => collection.toArray()));
-
+        const opts = !value ? {} : { filter: `displayName:ilike:${value}` };
+        const roots = await this.getRoots(opts);
         this.setState({ roots });
     };
 
@@ -260,16 +285,6 @@ function mergeChildren(root, children) {
         const parentPath = childPath.slice(0, childPath.length - 1);
         return assignChildren(root, parentPath, children);
     }
-}
-
-function getDefaultRoots(d2) {
-    return d2.models.organisationUnits
-        .list({
-            paging: false,
-            level: 1,
-            fields: "id,displayName,path,children::isNotEmpty",
-        })
-        .then(collection => collection.toArray());
 }
 
 const styles = {

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -79,7 +79,7 @@ export default class OrgUnitsSelector extends React.Component {
                       paging: false,
                       fields: "id,displayName",
                   }),
-            this.getRoots({}),
+            this.getRoots(),
         ]).then(([levels, groups, defaultRoots]) => {
             this.setState({
                 roots: defaultRoots,
@@ -89,7 +89,7 @@ export default class OrgUnitsSelector extends React.Component {
         });
     }
 
-    getRoots({ filter }) {
+    getRoots({ filter } = {}) {
         const { d2, listParams, rootIds } = this.props;
         const pagingOptions = { paging: true, pageSize: 10 };
         let options;
@@ -176,7 +176,7 @@ export default class OrgUnitsSelector extends React.Component {
     };
 
     filterOrgUnits = async value => {
-        const opts = !value ? {} : { filter: `displayName:ilike:${value}` };
+        const opts = value ? { filter: `displayName:ilike:${value}` } : undefined;
         const roots = await this.getRoots(opts);
         this.setState({ roots });
     };


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/vaccination-app/pull/237

### :memo: Implementation

This PR adds 2 props to the component `OrgUnitsSelector`:

- `listParams`. This value will be added to `d2.models.organisationUnits.list`, so we can use specific arguments supported by dhis ([docs](https://docs.dhis2.org/2.30/en/developer/html/dhis2_developer_manual_full.html#webapi_list_of_organisation_units)).

- `rootIds`. By default, all orgUnits were being displayed, now we can select a specific group. Note that we have an option in the endpoint `withinUserHierarchy` but this only allows to filter within the "data capture" orgUnits. When filtering by name, we do this filtering by JS (not possible to do both text/root inclusson filtering with a single API call).