### PR TITLE
[Wizard] Allow opening help messages from the app

### DIFF
--- a/src/dialog-button/DialogButton.jsx
+++ b/src/dialog-button/DialogButton.jsx
@@ -8,11 +8,25 @@ class DialogButton extends React.Component {
         buttonComponent: PropTypes.func.isRequired,
         title: PropTypes.string.isRequired,
         contents: PropTypes.string.isRequired,
+        initialIsOpen: PropTypes.bool,
+    };
+
+    static defaultProps = {
+        initialIsOpen: undefined,
     };
 
     state = {
-        isOpen: false,
+        isOpen: this.props.initialIsOpen,
+        props: this.props,
     };
+
+    static getDerivedStateFromProps(nextProps, prevState) {
+        if (prevState.props.initialIsOpen === undefined && nextProps.initialIsOpen !== undefined) {
+            return { isOpen: nextProps.initialIsOpen, props: nextProps };
+        } else {
+            return null;
+        }
+    }
 
     handleClickOpen = () => {
         this.setState({ isOpen: true });
@@ -31,7 +45,7 @@ class DialogButton extends React.Component {
                 <CustomButton onClick={this.handleClickOpen} />
 
                 <ConfirmationDialog
-                    isOpen={isOpen}
+                    isOpen={!!isOpen}
                     title={title}
                     description={contents}
                     onCancel={this.handleClose}

--- a/src/dialog-button/DialogButton.jsx
+++ b/src/dialog-button/DialogButton.jsx
@@ -18,12 +18,13 @@ class DialogButton extends React.Component {
     };
 
     state = {
-        isOpen: this.props.initialIsOpen,
+        isOpen: !!this.props.initialIsOpen,
         props: this.props,
     };
 
     static getDerivedStateFromProps(nextProps, prevState) {
-        if (prevState.props.initialIsOpen === undefined && nextProps.initialIsOpen !== undefined) {
+        // Force the dialog opening only when initialIsOpen transitions from undefined to true
+        if (prevState.props.initialIsOpen === undefined && nextProps.initialIsOpen) {
             return { isOpen: nextProps.initialIsOpen, props: nextProps };
         } else {
             return null;
@@ -49,7 +50,7 @@ class DialogButton extends React.Component {
                 <CustomButton onClick={this.handleClickOpen} />
 
                 <ConfirmationDialog
-                    isOpen={!!isOpen}
+                    isOpen={isOpen}
                     title={title}
                     description={contents}
                     onCancel={this.handleClose}

--- a/src/dialog-button/DialogButton.jsx
+++ b/src/dialog-button/DialogButton.jsx
@@ -9,10 +9,12 @@ class DialogButton extends React.Component {
         title: PropTypes.string.isRequired,
         contents: PropTypes.string.isRequired,
         initialIsOpen: PropTypes.bool,
+        isVisible: PropTypes.bool,
     };
 
     static defaultProps = {
         initialIsOpen: undefined,
+        isVisible: true,
     };
 
     state = {
@@ -37,8 +39,10 @@ class DialogButton extends React.Component {
     };
 
     render() {
-        const { buttonComponent: CustomButton, title, contents } = this.props;
+        const { buttonComponent: CustomButton, title, contents, isVisible } = this.props;
         const { isOpen } = this.state;
+
+        if (!isVisible) return null;
 
         return (
             <React.Fragment>

--- a/src/wizard/Wizard.jsx
+++ b/src/wizard/Wizard.jsx
@@ -222,7 +222,7 @@ class Wizard extends React.Component {
                                 {step.label}
                             </StepButton>
 
-                            <Help step={step} currentStepKey={currentStepKey} />
+                            {step.help && <Help step={step} currentStepKey={currentStepKey} />}
                         </Step>
                     ))}
                 </Stepper>

--- a/src/wizard/Wizard.jsx
+++ b/src/wizard/Wizard.jsx
@@ -161,19 +161,14 @@ class Wizard extends React.Component {
         this.setStep(stepKey);
     });
 
-    renderHelp = ({ step }) => {
-        const Button = ({ onClick }) => (
-            <IconButton tooltip={i18n.t("Help")} onClick={onClick}>
-                <Icon color="primary">help</Icon>
-            </IconButton>
-        );
-
+    renderHelp = ({ step, currentStepKey }) => {
         return (
             <DialogButton
-                buttonComponent={Button}
+                buttonComponent={HelpButton}
                 title={`${step.label} - ${i18n.t("Help")}`}
                 contents={step.help}
                 initialIsOpen={step.helpDialogIsInitialOpen}
+                isVisible={step.help && step.key === currentStepKey}
             />
         );
     };
@@ -227,7 +222,7 @@ class Wizard extends React.Component {
                                 {step.label}
                             </StepButton>
 
-                            {step.help && step === currentStep ? <Help step={step} /> : null}
+                            <Help step={step} currentStepKey={currentStepKey} />
                         </Step>
                     ))}
                 </Stepper>
@@ -257,5 +252,11 @@ class Wizard extends React.Component {
         );
     }
 }
+
+const HelpButton = ({ onClick }) => (
+    <IconButton tooltip={i18n.t("Help")} onClick={onClick}>
+        <Icon color="primary">help</Icon>
+    </IconButton>
+);
 
 export default withSnackbar(withStyles(styles)(Wizard));

--- a/src/wizard/Wizard.jsx
+++ b/src/wizard/Wizard.jsx
@@ -65,13 +65,16 @@ class Wizard extends React.Component {
     static propTypes = {
         initialStepKey: PropTypes.string.isRequired,
         onStepChangeRequest: PropTypes.func.isRequired,
+        onStepChange: PropTypes.func,
         useSnackFeedback: PropTypes.bool,
         snackbar: PropTypes.object.isRequired,
         steps: PropTypes.arrayOf(
             PropTypes.shape({
                 key: PropTypes.string.isRequired,
                 label: PropTypes.string.isRequired,
+                description: PropTypes.string,
                 component: PropTypes.func.isRequired,
+                helpDialogIsInitialOpen: PropTypes.bool,
             })
         ).isRequired,
         lastClickableStepIndex: PropTypes.number,
@@ -81,6 +84,10 @@ class Wizard extends React.Component {
         useSnackFeedback: false,
         lastClickableStepIndex: 0,
     };
+
+    componentDidMount() {
+        this.notifyStepChange(this.state.currentStepKey);
+    }
 
     getAdjacentSteps = () => {
         const { steps } = this.props;
@@ -115,6 +122,11 @@ class Wizard extends React.Component {
         );
     };
 
+    notifyStepChange(skepKey) {
+        const { onStepChange } = this.props;
+        if (onStepChange) onStepChange(skepKey);
+    }
+
     setStep = async newStepKey => {
         const { currentStepKey, lastClickableStepIndex } = this.state;
         const { onStepChangeRequest, steps } = this.props;
@@ -128,6 +140,7 @@ class Wizard extends React.Component {
 
         if (_(errorMessages).isEmpty()) {
             const newLastClickableStepIndex = Math.max(lastClickableStepIndex, newStepIndex);
+            this.notifyStepChange(newStepKey);
             this.setState({
                 currentStepKey: newStepKey,
                 lastClickableStepIndex: newLastClickableStepIndex,
@@ -160,6 +173,7 @@ class Wizard extends React.Component {
                 buttonComponent={Button}
                 title={`${step.label} - ${i18n.t("Help")}`}
                 contents={step.help}
+                initialIsOpen={step.helpDialogIsInitialOpen}
             />
         );
     };


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/vaccination-app/pull/238

Implementation:

- Make `DialogButton` opening available as a prop (`initialIsOpen`).
- Update `Wizard` to pass `step.helpDialogIsInitialOpen` to `DialogButton`.