### PR TITLE
[ObjectsTable] Do not call formatter on null/undefined props

### DIFF
--- a/src/helpers/d2.js
+++ b/src/helpers/d2.js
@@ -60,10 +60,8 @@ export function getFormatter(model, name) {
             return getValueForCollection;
         } else if (def.type === "URL") {
             return getValueForUrl;
-        } else {
-            return;
         }
     })();
 
-    return obj => (fn ? fn(obj[name]) : obj[name]);
+    return obj => (obj[name] && fn ? fn(obj[name]) : obj[name]);
 }


### PR DESCRIPTION
### :pushpin: References

### :memo: Implementation

- We are calling formatter even when value is null or undefined.

- This causes side-effects such as ```new Date()``` instead of ```undefined```

### :bookmark_tabs: Others

See the following example on https://github.com/EyeSeeTea/metadata-synchronization/pull/133.

Notice the details box and the lastExecuted property.

Before:

![image](https://user-images.githubusercontent.com/2181866/61296049-a6d17f00-a7d9-11e9-84f0-ff22883b36fc.png)

After:

![image](https://user-images.githubusercontent.com/2181866/61296010-93261880-a7d9-11e9-861d-426d2dc9265f.png)

