### PR TITLE
[Snackbar] Override styles to avoid empty space on multi-line messages

### DIFF
--- a/src/snackbar/SnackbarConsumer.jsx
+++ b/src/snackbar/SnackbarConsumer.jsx
@@ -46,7 +46,7 @@ const styles = theme => ({
     },
     iconVariant: {
         opacity: 0.9,
-        marginRight: theme.spacing.unit,
+        marginRight: theme.spacing.unit * 4, // Or anything between 30px and 38px
     },
     message: {
         display: "flex",

--- a/src/snackbar/SnackbarConsumer.jsx
+++ b/src/snackbar/SnackbarConsumer.jsx
@@ -14,6 +14,7 @@ import SnackbarContent from "@material-ui/core/SnackbarContent";
 import WarningIcon from "@material-ui/icons/Warning";
 import { withStyles } from "@material-ui/core/styles";
 import SnackbarContext from "./context";
+import { MuiThemeProvider, createMuiTheme } from "@material-ui/core";
 
 const anchorOrigin = {
     vertical: "bottom",
@@ -54,6 +55,19 @@ const styles = theme => ({
     },
 });
 
+const theme = createMuiTheme({
+    typography: {
+        useNextVariants: true,
+    },
+    overrides: {
+        MuiSnackbarContent: {
+            message: {
+                maxWidth: "85%",
+            },
+        },
+    },
+});
+
 const SnackbarConsumer = props => {
     const { classes } = props;
 
@@ -66,36 +80,41 @@ const SnackbarConsumer = props => {
                 }
 
                 return (
-                    <Snackbar
-                        anchorOrigin={anchorOrigin}
-                        open={snackbarIsOpen}
-                        autoHideDuration={autoHideDuration}
-                        onClose={closeSnackbar}
-                    >
-                        <SnackbarContent
-                            className={classes[variant]}
-                            aria-describedby="client-snackbar"
-                            message={
-                                <span id="client-snackbar" className={classes.message}>
-                                    <Icon
-                                        className={classNames(classes.icon, classes.iconVariant)}
-                                    />
-                                    {message}
-                                </span>
-                            }
-                            action={[
-                                <IconButton
-                                    key="close"
-                                    aria-label="Close"
-                                    color="inherit"
-                                    className={classes.close}
-                                    onClick={closeSnackbar}
-                                >
-                                    <CloseIcon className={classes.icon} />
-                                </IconButton>,
-                            ]}
-                        />
-                    </Snackbar>
+                    <MuiThemeProvider theme={theme}>
+                        <Snackbar
+                            anchorOrigin={anchorOrigin}
+                            open={snackbarIsOpen}
+                            autoHideDuration={autoHideDuration}
+                            onClose={closeSnackbar}
+                        >
+                            <SnackbarContent
+                                className={classes[variant]}
+                                aria-describedby="client-snackbar"
+                                message={
+                                    <span id="client-snackbar" className={classes.message}>
+                                        <Icon
+                                            className={classNames(
+                                                classes.icon,
+                                                classes.iconVariant
+                                            )}
+                                        />
+                                        {message}
+                                    </span>
+                                }
+                                action={[
+                                    <IconButton
+                                        key="close"
+                                        aria-label="Close"
+                                        color="inherit"
+                                        className={classes.close}
+                                        onClick={closeSnackbar}
+                                    >
+                                        <CloseIcon className={classes.icon} />
+                                    </IconButton>,
+                                ]}
+                            />
+                        </Snackbar>
+                    </MuiThemeProvider>
                 );
             }}
         </SnackbarContext.Consumer>


### PR DESCRIPTION
Closes #45 

Single line:
![image](https://user-images.githubusercontent.com/24643/61940483-cf096c80-af95-11e9-8983-79679ca55462.png)

Multi line:
![image](https://user-images.githubusercontent.com/24643/61940293-67532180-af95-11e9-87a1-1133820b3dee.png)
