### PR TITLE
[ObjectsTable] Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ Display D2 objects in a table with:
 -   Pagination.
 -   _Create_ button action.
 
+Whenever you want to update the objects table, pass a different `key` prop (i.e `new Date()`), as you would do with any other React component.
+
 ```
 const columns = [
     { name: "displayName", text: i18n.t("Name"), sortable: true },

--- a/src/data-table/DataTable.jsx
+++ b/src/data-table/DataTable.jsx
@@ -55,12 +55,7 @@ class DataTable extends React.Component {
     }
 
     renderContextMenu() {
-        const { contextMenuActions, isContextActionAllowed } = this.props;
-        const actionsToShow = contextMenuActions.filter(action =>
-            isContextActionAllowed(this.state.activeRows, action.name)
-        );
-
-        if (actionsToShow.length === 0) return null;
+        const actionsToShow = this.getActionsToShow(this.state.activeRows);
 
         return (
             <MultipleDataTableContextMenu
@@ -151,6 +146,12 @@ class DataTable extends React.Component {
         this.props.onActiveRowsChange(this.state.activeRows);
     };
 
+    getActionsToShow(activeRows) {
+        return this.props.contextMenuActions.filter(action =>
+            this.props.isContextActionAllowed(activeRows, action.name)
+        );
+    }
+
     handleRowClick = (event, rowSource) => {
         //Update activeRows according to click|ctlr+click
         var newActiveRows;
@@ -164,11 +165,10 @@ class DataTable extends React.Component {
             newActiveRows = [rowSource];
         }
 
-        //Update state
         this.setState(
             {
                 contextMenuTarget: event.currentTarget,
-                showContextMenu: true,
+                showContextMenu: this.getActionsToShow(newActiveRows).length > 0,
                 activeRows: newActiveRows,
             },
             this.notifyActiveRows

--- a/src/data-table/DataTable.jsx
+++ b/src/data-table/DataTable.jsx
@@ -60,6 +60,8 @@ class DataTable extends React.Component {
             isContextActionAllowed(this.state.activeRows, action.name)
         );
 
+        if (actionsToShow.length === 0) return null;
+
         return (
             <MultipleDataTableContextMenu
                 target={this.state.contextMenuTarget}

--- a/src/helpers/d2.js
+++ b/src/helpers/d2.js
@@ -48,6 +48,8 @@ function getValueForUrl(value) {
 }
 
 export function getFormatter(model, name) {
+    if (!model) return obj => obj[name];
+
     const def = model.modelValidations[name] || {};
     const isAccessField = def.type === "TEXT" && def.min === 8 && def.max === 8;
 

--- a/src/objects-table/ObjectsTable.js
+++ b/src/objects-table/ObjectsTable.js
@@ -24,7 +24,7 @@ class ObjectsTable extends React.Component {
         onButtonClick: PropTypes.func,
         pageSize: PropTypes.number.isRequired,
         model: PropTypes.object.isRequired,
-        initialSorting: PropTypes.array.isRequired, // [fieldName, "asc" | "desc"]
+        initialSorting: PropTypes.array, // [columnName: string, "asc" | "desc"]
         actions: PropTypes.arrayOf(
             PropTypes.shape({
                 name: PropTypes.string.isRequired,
@@ -45,7 +45,7 @@ class ObjectsTable extends React.Component {
                 style: PropTypes.object,
                 contents: PropTypes.element,
             })
-        ),
+        ).isRequired,
         /*  list: async function that returns paginated D2 objects.
 
             list(
@@ -125,13 +125,21 @@ class ObjectsTable extends React.Component {
         }));
     }
 
+    getDefaultSorting() {
+        const columnName = _(this.props.columns)
+            .map(column => (column.sortable ? column.name : null))
+            .compact()
+            .first();
+        return columnName ? [columnName, "asc"] : null;
+    }
+
     _getInitialState() {
         return {
             isLoading: true,
             page: 1,
             pager: { total: 0 },
             dataRows: [],
-            sorting: this.props.initialSorting,
+            sorting: this.props.initialSorting || this.getDefaultSorting(),
             searchValue: null,
             detailsObject: null,
             selection: new Set(this.props.initialSelection),

--- a/src/objects-table/ObjectsTable.js
+++ b/src/objects-table/ObjectsTable.js
@@ -381,7 +381,7 @@ class ObjectsTable extends React.Component {
         const primaryAction = defaultAction ? defaultAction.fn : undefined;
 
         return (
-            <div>
+            <div style={styles.mainWrapper}>
                 <div>
                     {!hideSearchBox && (
                         <div style={styles.searchBox}>
@@ -472,6 +472,7 @@ function calculatePageValue(pager, pageSize) {
 const styles = {
     searchBox: { float: "left", width: "33%" },
     pagination: { float: "right" },
+    mainWrapper: { marginTop: -10 },
     spinner: { float: "right" },
     clear: { clear: "both" },
     selectColumn: { width: "auto" },

--- a/src/objects-table/ObjectsTable.js
+++ b/src/objects-table/ObjectsTable.js
@@ -184,6 +184,7 @@ class ObjectsTable extends React.Component {
                 dataRows: objects,
                 page: newPage,
                 allObjects,
+                detailsObject: null,
             },
             this.notifySelectionChange
         );

--- a/src/objects-table/ObjectsTable.js
+++ b/src/objects-table/ObjectsTable.js
@@ -68,6 +68,7 @@ class ObjectsTable extends React.Component {
         initialSelection: PropTypes.array,
         buttonLabel: PropTypes.node,
         hideSearchBox: PropTypes.bool,
+        forceSelectionColumn: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -75,6 +76,7 @@ class ObjectsTable extends React.Component {
         buttonLabel: null,
         hideSearchBox: false,
         initialSelection: [],
+        forceSelectionColumn: undefined,
     };
 
     constructor(props) {
@@ -104,10 +106,12 @@ class ObjectsTable extends React.Component {
     };
 
     getSelectColumn() {
-        const { actions } = this.props;
+        const { actions, forceSelectionColumn } = this.props;
         const isSomeActionMultiple = _(actions).some("multiple");
+        const columnIsVisible =
+            forceSelectionColumn || (_.isNil(forceSelectionColumn) && isSomeActionMultiple);
 
-        if (!isSomeActionMultiple) return null;
+        if (!columnIsVisible) return null;
 
         const selectedColumnContents = (
             <SimpleCheckBox

--- a/src/objects-table/ObjectsTable.js
+++ b/src/objects-table/ObjectsTable.js
@@ -22,7 +22,7 @@ class ObjectsTable extends React.Component {
         d2: PropTypes.object.isRequired,
         onButtonClick: PropTypes.func,
         pageSize: PropTypes.number.isRequired,
-        model: PropTypes.object.isRequired,
+        model: PropTypes.object,
         initialSorting: PropTypes.array, // [columnName: string, "asc" | "desc"]
         actions: PropTypes.arrayOf(
             PropTypes.shape({

--- a/src/objects-table/ObjectsTable.js
+++ b/src/objects-table/ObjectsTable.js
@@ -329,9 +329,9 @@ class ObjectsTable extends React.Component {
     }
 }
 
-function calculatePageValue(pager, defaultPerPage) {
-    const { total, pageCount, page, query } = pager;
-    const pageSize = query ? query.pageSize : defaultPerPage;
+function calculatePageValue(pager, pageSize) {
+    const { total, page } = pager;
+    const pageCount = Math.ceil(total / pageSize);
     const pageCalculationValue = total - (total - (pageCount - (pageCount - page)) * pageSize);
     const startItem = 1 + pageCalculationValue - pageSize;
     const endItem = pageCalculationValue;


### PR DESCRIPTION
Closes #10 

High Priority
- [x] ObjectsTable: Hide checkboxes if there are no fields with multiple set to true.
- [x] Apply branch fix/calculate-page-value
- [x] ObjectsTable: We have `initialSorting` as a required prop, make it optional and assume first sortable column ASC is the default order.
- [x] Update readme for ObjectsTable with explanation regarding prop 'key' to update it.

Low Priority
- [x] Reduce marginTop by 10px, too much space.
- [x] Change model prop to optional (See https://github.com/EyeSeeTea/metadata-synchronization/issues/7 -> Remove model prop from instance-configurator)
- [x] Hide details panel if table refreshes otherwise it can be confusing for the user.