### PR TITLE
Add withElevation prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ const MyOrgUnitsSelector = () => (
         levels={[1, 2]}
         rootIds={["ImspTQPwCqd"]}
         listParams={{ maxLevel: 4 }}
+        withElevation={false}
     />
 );
 ```

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -195,13 +195,11 @@ export default class OrgUnitsSelector extends React.Component {
         const getClass = root => `ou-root-${root.path.split("/").length - 1}`;
         const leftStyles = someControlsVisible ? styles.left : styles.leftFullWidth;
 
-        if (!withElevation) {
-            styles.cardWide.boxShadow = "none";
-        }
-
+        const cardWideStyle = withElevation ? styles.cardWide : {...styles.cardWide, boxShadow: "none"}
+ 
         return (
             <div>
-                <Card style={styles.cardWide}>
+                <Card style={cardWideStyle}>
                     <CardText style={styles.cardText}>
                         <div style={styles.searchBox}>
                             <SearchBox onChange={this.filterOrgUnits} />

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -29,6 +29,7 @@ export default class OrgUnitsSelector extends React.Component {
             filterByGroup: PropTypes.bool,
             selectAll: PropTypes.bool,
         }),
+        withElevation: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -38,6 +39,7 @@ export default class OrgUnitsSelector extends React.Component {
             filterByGroup: true,
             selectAll: true,
         },
+        withElevation: true,
     };
 
     static childContextTypes = {
@@ -185,13 +187,17 @@ export default class OrgUnitsSelector extends React.Component {
         if (!this.state.levels) return null;
 
         const { levels, currentRoot, roots, groups } = this.state;
-        const { selected, controls } = this.props;
+        const { selected, controls, withElevation } = this.props;
         const { filterByLevel, filterByGroup, selectAll } = controls;
         const someControlsVisible = filterByLevel || filterByGroup || selectAll;
         const { renderOrgUnitSelectTitle: OrgUnitSelectTitle } = this;
         const initiallyExpanded = roots.length > 1 ? [] : roots.map(ou => ou.path);
         const getClass = root => `ou-root-${root.path.split("/").length - 1}`;
         const leftStyles = someControlsVisible ? styles.left : styles.leftFullWidth;
+
+        if (!withElevation) {
+            styles.cardWide.boxShadow = "none";
+        }
 
         return (
             <div>


### PR DESCRIPTION
### :pushpin: References

* **related  PR:** https://github.com/EyeSeeTea/metadata-synchronization/pull/195

### :memo: Implementation

The goal of this PR is to create a new prop in OrgUnitsSelector to assign from outside if elevation must be visible or not.

OrgUnitsSelector component use this import `import Card from "material-ui/Card/Card"` and seems an old card component where elevation property not work. On this import `import Card from "material-ui/Core"` elevation property work.

To modify OrgUnitsSelector as little as possible, I have created a new prop withElevation with true value by default for maintaining current behaviour.

If withElevation is false I have added a new field boxShadow to styles.cardWide assigning "none" value.

