### PR TITLE
[MultiSelector] Allow search box filtering

### DIFF
--- a/src/multi-selector/MultiSelector.jsx
+++ b/src/multi-selector/MultiSelector.jsx
@@ -35,12 +35,14 @@ class MultiSelector extends React.Component {
         options: optionsPropType.isRequired,
         selected: PropTypes.arrayOf(PropTypes.string),
         onChange: PropTypes.func.isRequired,
+        searchFilterLabel: PropTypes.string,
     };
 
     static defaultProps = {
         height: 300,
         ordered: true,
         selected: undefined,
+        searchFilterLabel: undefined,
     };
 
     // Required by <GroupEditor>

--- a/src/multi-selector/MultiSelector.jsx
+++ b/src/multi-selector/MultiSelector.jsx
@@ -4,6 +4,7 @@ import GroupEditor from "@dhis2/d2-ui-group-editor/GroupEditor.component";
 import GroupEditorWithOrdering from "@dhis2/d2-ui-group-editor/GroupEditorWithOrdering.component";
 import { Store } from "@dhis2/d2-ui-core";
 import { withStyles } from "@material-ui/core/styles";
+import TextField from "material-ui/TextField";
 import i18n from "../utils/i18n";
 
 const styles = () => ({
@@ -24,6 +25,7 @@ class MultiSelector extends React.Component {
 
     state = {
         selected: [],
+        filterText: "",
     };
 
     static propTypes = {
@@ -81,8 +83,13 @@ class MultiSelector extends React.Component {
         return this.updateSelected(_selected => values);
     };
 
+    textFilterChange = event => {
+        this.setState({ filterText: event.target.value });
+    };
+
     render() {
-        const { height, options, classes, ordered } = this.props;
+        const { height, options, classes, ordered, searchFilterLabel } = this.props;
+        const { filterText } = this.state;
 
         const selected = this.getSelected();
         const itemStore = Store.create();
@@ -96,12 +103,24 @@ class MultiSelector extends React.Component {
 
         return (
             <div className={classes.wrapper} data-multi-selector={true}>
+                {searchFilterLabel && (
+                    <TextField
+                        value={filterText}
+                        type="search"
+                        onChange={this.textFilterChange}
+                        floatingLabelText={searchFilterLabel}
+                        data-test="search"
+                        fullWidth
+                    />
+                )}
+
                 <GroupEditorComponent
                     itemStore={itemStore}
                     assignedItemStore={assignedItemStore}
                     onAssignItems={this.assignItems}
                     onRemoveItems={this.removeItems}
                     height={height}
+                    filterText={filterText}
                     {...extraProps}
                 />
             </div>


### PR DESCRIPTION
### Implementation

- Add a new optional prop ``searchFilterLabel``
  - If defined a search box will appear and will filter in both sides
  - If not defined the search box will be hidden
- We rely on the filtering of the ``GroupEditorWithOrdering``
- We use old ``material-ui`` because we use everywhere the same search box and to maintain the look and feel, once we update everywhere to v4 we should take care of this component too