### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ const MyOrgUnitsSelector = () => (
         rootIds={["ImspTQPwCqd"]}
         listParams={{ maxLevel: 4 }}
         withElevation={false}
+        typeInput="radio"
+        selectableLevels=[1,3] // the biggest selectableLevel has not children in OrgUnitTree
     />
 );
 ```


### PR DESCRIPTION
Two more props for `OrgUnitSelector`:
- typeInput: `OrgUnitTree`/`TreeView` input can change with `typeInput`prop (by default is a checkbox) 
- selectableLevels: it's an array of OU levels that can be selectable. The biggest number of `selectableLevels` has not children in `OrgUnitTree`