### PR TITLE
[DataTable] Recalculate pagination programmatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.0.0-beta.7",
+    "version": "1.0.0-beta.8",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -70,7 +70,7 @@ export interface DataTableProps<T extends ReferenceObject> {
     // State controlled by parent
     sorting?: TableSorting<T>;
     selection?: string[];
-    pagination?: TablePagination;
+    pagination?: Partial<TablePagination>;
     onChange?(state: TableState<T>): void;
 }
 
@@ -100,21 +100,19 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
         order: "asc" as const,
     };
     const initialSelection = initialState.selection || [];
-    const initialPagination: TablePagination = {
-        pageSize: 25,
-        total: undefined,
-        page: 1,
-        pageSizeOptions: [10, 25, 50, 100],
-        ...initialState.pagination,
-    };
 
     const [stateSorting, updateSorting] = useState(initialSorting);
     const [stateSelection, updateSelection] = useState(initialSelection);
-    const [statePagination, updatePagination] = useState(initialPagination);
+    const [statePagination, updatePagination] = useState(initialState.pagination);
 
     const sorting = controlledSorting || stateSorting;
     const selection = controlledSelection || stateSelection;
-    const pagination = controlledPagination || statePagination;
+    const pagination = _.merge({
+        pageSize: 25,
+        total: undefined,
+        page: 1,
+        pageSizeOptions: [10, 25, 50, 100]
+    }, statePagination, controlledPagination);
 
     const rowObjects = controlledPagination ? rows : sortObjects(rows, pagination, sorting);
     const primaryAction = _(availableActions).find({ primary: true }) || availableActions[0];

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -101,7 +101,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
     };
     const initialSelection = initialState.selection || [];
     const initialPagination: TablePagination = {
-        pageSize: 10,
+        pageSize: 25,
         total: undefined,
         page: 1,
         pageSizeOptions: [10, 25, 50, 100],

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -102,7 +102,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
     const initialSelection = initialState.selection || [];
     const initialPagination: TablePagination = {
         pageSize: 10,
-        total: rows.length,
+        total: undefined,
         page: 1,
         pageSizeOptions: [10, 25, 50, 100],
         ...initialState.pagination,
@@ -145,8 +145,9 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
     };
 
     const handleSortingChange = (sorting: TableSorting<T>) => {
-        updateSorting(sorting);
         const newPagination = { ...pagination, page: 1 };
+        updateSorting(sorting);
+        updatePagination(newPagination);
         onChange({ selection, pagination: newPagination, sorting });
     };
 
@@ -180,7 +181,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
                     <div className={classes.spacer}></div>
                     {loading && <CircularProgress size={30} />}
                     <DataTablePagination
-                        pagination={{ total: rows.length, ...pagination }} // TODO: Verify this
+                        pagination={{ ...pagination, total: pagination.total || rows.length }}
                         onChange={handlePaginationChange}
                     />
                 </React.Fragment>

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -107,12 +107,16 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
 
     const sorting = controlledSorting || stateSorting;
     const selection = controlledSelection || stateSelection;
-    const pagination = _.merge({
-        pageSize: 25,
-        total: undefined,
-        page: 1,
-        pageSizeOptions: [10, 25, 50, 100]
-    }, statePagination, controlledPagination);
+    const pagination = _.merge(
+        {
+            pageSize: 25,
+            total: undefined,
+            page: 1,
+            pageSizeOptions: [10, 25, 50, 100],
+        },
+        statePagination,
+        controlledPagination
+    );
 
     const rowObjects = controlledPagination ? rows : sortObjects(rows, pagination, sorting);
     const primaryAction = _(availableActions).find({ primary: true }) || availableActions[0];

--- a/src/data-table/types.ts
+++ b/src/data-table/types.ts
@@ -30,8 +30,8 @@ export interface TableSorting<T extends ReferenceObject> {
 }
 
 export interface TablePagination {
-    pageSizeOptions?: number[];
     pageSize: number;
+    pageSizeOptions: number[];
     total: number;
     page: number;
 }


### PR DESCRIPTION
Since we were forcing the total to be initialized on first render we took ``objects.length`` only once, if the application updates the objects collection we still had the original value.

Instead set it to undefined on initialPagination and calculate the value every time. Note that we would not calculate it if the pagination is controlled by the app.

Also in uncontrolled mode fix the reset pagination to page 1 when sorting changes and make default page size 25. (#97)

### To test

Option 1:
- https://github.com/EyeSeeTea/metadata-synchronization/pull/252
- Events sync wizard, "Events" step.

Option 2:

- Simple ObjectsTable with rows initially ``[]`` and then populated without controlling the pagination.