### PR TITLE
[DataTable] Add basic support for column hiding

### DIFF
--- a/src/data-table/ColumnSelectorDialog.tsx
+++ b/src/data-table/ColumnSelectorDialog.tsx
@@ -11,8 +11,8 @@ import { DialogContent, Checkbox } from "@material-ui/core";
 
 interface ColumnSelectorDialogProps<T extends ReferenceObject> {
     columns: TableColumn<T>[];
-    visibleColumns: (keyof T)[];
-    onChange: (visibleColumns: (keyof T)[]) => void;
+    visibleColumns: string[];
+    onChange: (visibleColumns: string[]) => void;
     onCancel: () => void;
 }
 
@@ -21,7 +21,7 @@ export function ColumnSelectorDialog<T extends ReferenceObject>(
 ) {
     const { columns, visibleColumns, onChange, onCancel } = props;
 
-    const toggleElement = (name: keyof T) => {
+    const toggleElement = (name: string) => {
         const newSelection = !visibleColumns.includes(name)
             ? [...visibleColumns, name]
             : visibleColumns.filter(item => item !== name);

--- a/src/data-table/ColumnSelectorDialog.tsx
+++ b/src/data-table/ColumnSelectorDialog.tsx
@@ -1,0 +1,77 @@
+import i18n from "@dhis2/d2-i18n";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import React from "react";
+import _ from "lodash";
+import { ConfirmationDialog, ReferenceObject, TableColumn } from "..";
+import { DialogContent, Checkbox } from "@material-ui/core";
+
+interface ColumnSelectorDialogProps<T extends ReferenceObject> {
+    columns: TableColumn<T>[];
+    visibleColumns: (keyof T)[];
+    onChange: (visibleColumns: (keyof T)[]) => void;
+    onCancel: () => void;
+}
+
+export function ColumnSelectorDialog<T extends ReferenceObject>(
+    props: ColumnSelectorDialogProps<T>
+) {
+    const { columns, visibleColumns, onChange, onCancel } = props;
+
+    const toggleElement = (name: keyof T) => {
+        const newSelection = !visibleColumns.includes(name)
+            ? [...visibleColumns, name]
+            : visibleColumns.filter(item => item !== name);
+        onChange(newSelection);
+    };
+
+    return (
+        <ConfirmationDialog
+            isOpen={true}
+            title={i18n.t("Columns to show in table")}
+            onCancel={onCancel}
+            cancelText={i18n.t("Close")}
+            fullWidth
+            disableEnforceFocus
+        >
+            <DialogContent>
+                <Table>
+                    <TableHead>
+                        <TableRow>
+                            <TableCell colSpan={12}>{i18n.t("Column")}</TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {columns.map(({ name, text }) => {
+                            const checked = visibleColumns.includes(name);
+                            const disabled = visibleColumns.length <= 1 && checked;
+
+                            return (
+                                <TableRow key={`cell-${name}`}>
+                                    <TableCell
+                                        component="th"
+                                        scope="row"
+                                        onClick={() => !disabled && toggleElement(name)}
+                                    >
+                                        <Checkbox
+                                            color={"primary"}
+                                            checked={checked}
+                                            disabled={disabled}
+                                            tabIndex={-1}
+                                        />
+                                        {text}
+                                    </TableCell>
+                                </TableRow>
+                            );
+                        })}
+                    </TableBody>
+                </Table>
+            </DialogContent>
+        </ConfirmationDialog>
+    );
+}
+
+export default ColumnSelectorDialog;

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -123,7 +123,9 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
         controlledPagination
     );
 
-    const rowObjects = controlledPagination ? rows : sortObjects(rows, pagination, sorting);
+    const rowObjects = controlledPagination
+        ? rows
+        : sortObjects(rows, columns, pagination, sorting);
     const primaryAction = _(availableActions).find({ primary: true }) || availableActions[0];
     const allSelected =
         rowObjects.length > 0 &&

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -61,6 +61,7 @@ export interface DataTableProps<T extends ReferenceObject> {
     initialState?: TableInitialState<T>;
     forceSelectionColumn?: boolean;
     hideSelectionMessages?: boolean;
+    hideColumnVisibilityOptions?: boolean;
     tableNotifications?: TableNotification[];
     filterComponents?: ReactNode; // Portal to the navigation toolbar
     sideComponents?: ReactNode; // Portal to right-most of the Data Table
@@ -83,6 +84,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
         initialState = {},
         forceSelectionColumn,
         hideSelectionMessages,
+        hideColumnVisibilityOptions,
         tableNotifications = [],
         filterComponents,
         sideComponents,
@@ -100,10 +102,13 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
         order: "asc" as const,
     };
     const initialSelection = initialState.selection || [];
+    const initialPagination = initialState.pagination;
+    const initialVisibleColumns = columns.filter(({ hidden }) => !hidden).map(({ name }) => name);
 
     const [stateSorting, updateSorting] = useState(initialSorting);
     const [stateSelection, updateSelection] = useState(initialSelection);
-    const [statePagination, updatePagination] = useState(initialState.pagination);
+    const [statePagination, updatePagination] = useState(initialPagination);
+    const [visibleColumns, updateVisibleColumns] = useState(initialVisibleColumns);
 
     const sorting = controlledSorting || stateSorting;
     const selection = controlledSelection || stateSelection;
@@ -193,17 +198,21 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
                     <Table className={classes.table} size={"medium"}>
                         <DataTableHeader
                             columns={columns}
+                            visibleColumns={visibleColumns}
+                            onVisibleColumnsChange={updateVisibleColumns}
                             sorting={sorting}
-                            onChange={handleSortingChange}
+                            onSortingChange={handleSortingChange}
                             onSelectAllClick={handleSelectAllClick}
                             allSelected={allSelected}
                             tableNotifications={[...tableNotifications, ...selectionMessages]}
                             handleSelectionChange={handleSelectionChange}
                             enableMultipleAction={enableMultipleAction}
+                            hideColumnVisibilityOptions={hideColumnVisibilityOptions}
                         />
                         <DataTableBody
                             rows={rowObjects}
                             columns={columns}
+                            visibleColumns={visibleColumns}
                             sorting={sorting}
                             selected={selection}
                             onChange={handleSelectionChange}

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -126,7 +126,6 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
     const rowObjects = controlledPagination
         ? rows
         : sortObjects(rows, columns, pagination, sorting);
-    const primaryAction = _(availableActions).find({ primary: true }) || availableActions[0];
     const allSelected =
         rowObjects.length > 0 &&
         _.difference(rowObjects.map(row => row.id), selection).length === 0;
@@ -219,7 +218,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
                             selected={selection}
                             onChange={handleSelectionChange}
                             openContextualMenu={handleOpenContextualMenu}
-                            primaryAction={primaryAction}
+                            availableActions={availableActions}
                             enableMultipleAction={enableMultipleAction}
                             loading={loading}
                             childrenKeys={childrenKeys}

--- a/src/data-table/DataTableBody.tsx
+++ b/src/data-table/DataTableBody.tsx
@@ -40,6 +40,7 @@ const rotateIconStyle = (isOpen: boolean) => ({
 export interface DataTableBodyProps<T extends ReferenceObject> {
     rows: T[];
     columns: TableColumn<T>[];
+    visibleColumns: (keyof T)[];
     sorting: TableSorting<T>;
     primaryAction?: TableAction<T>;
     selected: string[];
@@ -54,6 +55,7 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
     const {
         rows,
         columns,
+        visibleColumns,
         sorting,
         primaryAction,
         selected,
@@ -151,15 +153,17 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
                         </TableCell>
                     )}
 
-                    {columns.map(column => (
-                        <TableCell
-                            key={`${labelId}-column-${column.name}`}
-                            scope="row"
-                            align="left"
-                        >
-                            {formatRowValue(column, row)}
-                        </TableCell>
-                    ))}
+                    {columns
+                        .filter(({ name }) => visibleColumns.includes(name))
+                        .map(column => (
+                            <TableCell
+                                key={`${labelId}-column-${column.name}`}
+                                scope="row"
+                                align="left"
+                            >
+                                {formatRowValue(column, row)}
+                            </TableCell>
+                        ))}
 
                     <TableCell key={`${labelId}-actions`} padding="none" align={"center"}>
                         {primaryAction && (

--- a/src/data-table/DataTableBody.tsx
+++ b/src/data-table/DataTableBody.tsx
@@ -40,7 +40,7 @@ const rotateIconStyle = (isOpen: boolean) => ({
 export interface DataTableBodyProps<T extends ReferenceObject> {
     rows: T[];
     columns: TableColumn<T>[];
-    visibleColumns: (keyof T)[];
+    visibleColumns: string[];
     sorting: TableSorting<T>;
     primaryAction?: TableAction<T>;
     selected: string[];

--- a/src/data-table/DataTableHeader.tsx
+++ b/src/data-table/DataTableHeader.tsx
@@ -61,7 +61,7 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
         handleSelectionChange = _.noop,
         onSelectAllClick = _.noop,
         enableMultipleAction,
-        hideColumnVisibilityOptions = true,
+        hideColumnVisibilityOptions = false,
     } = props;
 
     const { field, order } = sorting;

--- a/src/data-table/DataTableHeader.tsx
+++ b/src/data-table/DataTableHeader.tsx
@@ -36,8 +36,8 @@ const useStyles = makeStyles({
 
 export interface DataTableHeaderProps<T extends ReferenceObject> {
     columns: TableColumn<T>[];
-    visibleColumns: (keyof T)[];
-    onVisibleColumnsChange?(newVisibleColumns: (keyof T)[]): void;
+    visibleColumns: string[];
+    onVisibleColumnsChange?(newVisibleColumns: string[]): void;
     sorting: TableSorting<T>;
     onSortingChange?(newSorting: TableSorting<T>): void;
     allSelected?: boolean;
@@ -67,7 +67,7 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
     const { field, order } = sorting;
     const [openColumnReorder, setOpenColumnReorder] = useState<boolean>(false);
 
-    const createSortHandler = (property: keyof T) => (_event: React.MouseEvent<unknown>) => {
+    const createSortHandler = (property: string) => (_event: React.MouseEvent<unknown>) => {
         const isDesc = field === property && order === "desc";
         onSortingChange({ field: property, order: isDesc ? "asc" : "desc" });
     };

--- a/src/data-table/types.ts
+++ b/src/data-table/types.ts
@@ -56,4 +56,4 @@ export interface TableNotification {
     newSelection?: string[];
 }
 
-export type ObjectsTableDetailField<T extends ReferenceObject> = Omit<TableColumn<T>, "sortable">;
+export type ObjectsTableDetailField<T extends ReferenceObject> = Pick<TableColumn<T>, "name" | "text" | "getValue">;

--- a/src/data-table/types.ts
+++ b/src/data-table/types.ts
@@ -8,7 +8,7 @@ export interface TableObject extends ReferenceObject {
 }
 
 export interface TableColumn<T extends ReferenceObject> {
-    name: keyof T;
+    name: keyof T | string;
     text: string;
     sortable?: boolean;
     hidden?: boolean;

--- a/src/data-table/types.ts
+++ b/src/data-table/types.ts
@@ -11,6 +11,7 @@ export interface TableColumn<T extends ReferenceObject> {
     name: keyof T;
     text: string;
     sortable?: boolean;
+    hidden?: boolean;
     getValue?(row: T, defaultValue: ReactNode): ReactNode;
 }
 

--- a/src/data-table/types.ts
+++ b/src/data-table/types.ts
@@ -8,7 +8,7 @@ export interface TableObject extends ReferenceObject {
 }
 
 export interface TableColumn<T extends ReferenceObject> {
-    name: keyof T | string;
+    name: string;
     text: string;
     sortable?: boolean;
     hidden?: boolean;
@@ -26,7 +26,7 @@ export interface TableAction<T extends ReferenceObject> {
 }
 
 export interface TableSorting<T extends ReferenceObject> {
-    field: keyof T;
+    field: string;
     order: "asc" | "desc";
 }
 

--- a/src/data-table/utils/selection.tsx
+++ b/src/data-table/utils/selection.tsx
@@ -64,7 +64,7 @@ export function getSelectionMessages<T extends ReferenceObject>(
                 .value()
         )
         .flatten()
-        .map(({id}) => id)
+        .map(({ id }) => id)
         .value();
     const selection = _.difference(tableSelection, childrenIds);
 

--- a/src/data-table/utils/sorting.tsx
+++ b/src/data-table/utils/sorting.tsx
@@ -1,17 +1,23 @@
 import _ from "lodash";
-
-import { ReferenceObject, TablePagination, TableSorting } from "../types";
+import { ReferenceObject, TableColumn, TablePagination, TableSorting } from "../types";
+import { formatRowValue } from "./formatting";
 
 export function sortObjects<T extends ReferenceObject>(
     rows: T[],
+    columns: TableColumn<T>[],
     tablePagination: TablePagination,
     tableSorting: TableSorting<T>
 ) {
     const { field, order } = tableSorting;
     const { page, pageSize } = tablePagination;
+    const column = columns.find(({ name }) => name === field);
     const realPage = page - 1;
 
     return _(rows)
+        .map(row => ({
+            ...row,
+            [field]: columns ? formatRowValue(column, row) : row[field as keyof T],
+        }))
         .orderBy([field], [order])
         .slice(realPage * pageSize, realPage * pageSize + pageSize)
         .value();


### PR DESCRIPTION
### :memo: Implementation

- [FIX] Sort columns with ``getValue()``
- [BREAKING] TableColumn's ``name`` is now ``string`` instead of ``keyof T``. There might be columns that do not reference any property of T.
- [FEATURE] Allow to hide columns with ``hide === true``
- [FEATURE] Allow to show/hide columns on-demand through a dialog (can be disabled with ``hideColumnVisibilityOptions``

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/71644450-d7926b80-2cc8-11ea-81d9-5e6506f4b006.png)
![image](https://user-images.githubusercontent.com/2181866/71644451-dbbe8900-2cc8-11ea-8f9f-67b55319c735.png)
