### PR TITLE
[ObjectsTable] Allow sending selection customization from application

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.0.1",
+    "version": "1.0.2-beta.1",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.0.2-beta.1",
+    "version": "1.0.2-beta.2",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/data-table/DataTableBody.tsx
+++ b/src/data-table/DataTableBody.tsx
@@ -82,12 +82,13 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
         const handleClick = (event: MouseEvent<unknown>) => {
             const { tagName, type = null } = event.target as HTMLAnchorElement;
             const isCheckboxClick = tagName.localeCompare("input") && type === "checkbox";
+            const activeSelection = _.reject(selected, { indeterminate: true });
 
             if (event.type === "contextmenu") {
                 event.preventDefault();
                 contextualAction(event);
             } else if (enableMultipleAction && (isEventCtrlClick(event) || isCheckboxClick)) {
-                onChange(updateSelection(selected, row));
+                onChange(updateSelection(activeSelection, row));
             } else if (primaryAction && primaryAction.onClick) {
                 primaryAction.onClick([row]);
             }

--- a/src/data-table/DataTableHeader.tsx
+++ b/src/data-table/DataTableHeader.tsx
@@ -11,7 +11,13 @@ import _ from "lodash";
 import React, { useState } from "react";
 import ColumnSelectorDialog from "./ColumnSelectorDialog";
 import { DataTableNotifications } from "./DataTableNotifications";
-import { ReferenceObject, TableColumn, TableNotification, TableSorting } from "./types";
+import {
+    ReferenceObject,
+    TableColumn,
+    TableNotification,
+    TableSorting,
+    TableSelection,
+} from "./types";
 
 const useStyles = makeStyles({
     visuallyHidden: {
@@ -41,7 +47,7 @@ export interface DataTableHeaderProps<T extends ReferenceObject> {
     onSortingChange?(newSorting: TableSorting<T>): void;
     allSelected?: boolean;
     tableNotifications?: TableNotification[];
-    handleSelectionChange?(newSelection: string[]): void;
+    handleSelectionChange?(newSelection: TableSelection[]): void;
     onSelectAllClick?: (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => void;
     enableMultipleAction: boolean;
     hideColumnVisibilityOptions?: boolean;

--- a/src/data-table/types.ts
+++ b/src/data-table/types.ts
@@ -38,7 +38,7 @@ export interface TablePagination {
 }
 
 export interface TableState<T extends ReferenceObject> {
-    selection: string[];
+    selection: TableSelection[];
     sorting: TableSorting<T>;
     pagination: TablePagination;
 }
@@ -53,7 +53,14 @@ export interface TableNotification {
     // These props should be refactored and included everything into (...args) => ReactNode
     message: ReactNode;
     link?: string;
-    newSelection?: string[];
+    newSelection?: TableSelection[];
+}
+
+export interface TableSelection {
+    id: string;
+    checked?: boolean;
+    indeterminate?: boolean;
+    icon?: ReactNode;
 }
 
 export type ObjectsTableDetailField<T extends ReferenceObject> = Pick<

--- a/src/data-table/utils/selection.tsx
+++ b/src/data-table/utils/selection.tsx
@@ -35,9 +35,7 @@ export function getActionRows<T extends ReferenceObject>(
     selection: TableSelection[]
 ) {
     const isRowInSelection = _.some(selection, { id: selectedRow.id });
-    const selectedRows = _(allRows)
-        .intersectionBy(selection, "id")
-        .value();
+    const selectedRows = _.intersectionBy(allRows, selection, "id");
 
     return isRowInSelection ? selectedRows : [selectedRow];
 }

--- a/src/data-table/utils/selection.tsx
+++ b/src/data-table/utils/selection.tsx
@@ -34,10 +34,9 @@ export function getActionRows<T extends ReferenceObject>(
     allRows: T[],
     selection: TableSelection[]
 ) {
-    const isRowInSelection = !!_.find(selection, { id: selectedRow.id });
-    const selectedRows = _(selection)
-        .map(({ id }) => _.find(allRows, ["id", id]))
-        .compact()
+    const isRowInSelection = _.some(selection, { id: selectedRow.id });
+    const selectedRows = _(allRows)
+        .intersectionBy(selection, "id")
         .value();
 
     return isRowInSelection ? selectedRows : [selectedRow];

--- a/src/data-table/utils/selection.tsx
+++ b/src/data-table/utils/selection.tsx
@@ -36,9 +36,9 @@ export function getActionRows<T extends ReferenceObject>(
 ) {
     const isRowInSelection = !!_.find(selection, { id: selectedRow.id });
     const selectedRows = _(selection)
-        .map(({ id }) => _.find(allRows, { id }))
+        .map(({ id }) => _.find(allRows, ["id", id]))
         .compact()
-        .value() as T[];
+        .value();
 
     return isRowInSelection ? selectedRows : [selectedRow];
 }

--- a/src/group-editor/GroupEditor.component.js
+++ b/src/group-editor/GroupEditor.component.js
@@ -115,8 +115,8 @@ export default class GroupEditor extends Component {
     getItemStoreIsCollection() {
         return (
             this.props.itemStore.state !== undefined &&
-            (typeof this.props.itemStore.state.values === "function" &&
-                typeof this.props.itemStore.state.has === "function")
+            typeof this.props.itemStore.state.values === "function" &&
+            typeof this.props.itemStore.state.has === "function"
         );
     }
     getItemStoreIsArray() {
@@ -128,8 +128,8 @@ export default class GroupEditor extends Component {
     getAssignedItemStoreIsCollection() {
         return (
             this.props.assignedItemStore.state !== undefined &&
-            (typeof this.props.assignedItemStore.state.values === "function" &&
-                typeof this.props.assignedItemStore.state.has === "function")
+            typeof this.props.assignedItemStore.state.values === "function" &&
+            typeof this.props.assignedItemStore.state.has === "function"
         );
     }
     getAssignedItemStoreIsArray() {

--- a/src/old-objects-table/ObjectsTable.js
+++ b/src/old-objects-table/ObjectsTable.js
@@ -315,7 +315,10 @@ class ObjectsTable extends React.Component {
         if (_.isEmpty(dataRows) || disableMultiplePageSelection) return [];
 
         const allSelected = selection.size === pager.total;
-        const selectionInOtherPages = _.difference([...selection], dataRows.map(dr => dr.id));
+        const selectionInOtherPages = _.difference(
+            [...selection],
+            dataRows.map(dr => dr.id)
+        );
         const allSelectedInPage = dataRows.every(row => selection.has(row.id));
         const multiplePagesAvailable = pager.total > dataRows.length;
         const selectAllImplemented = allObjects.size === pager.total;


### PR DESCRIPTION
### 🎯 Objectives

- Allow excluding some rows from parent-children rows

### :memo: Implementation

- Change selection type from ``string[]`` to ``TableSelection[]``
- ``TableSelection`` allows to provide ``checked``, ``indetermindate`` and ``icon`` props to the row CheckBox API.
- Remove old ad-hoc children auto-selection

### :art: Screenshots

![image](https://user-images.githubusercontent.com/2181866/72055923-f21da380-32cb-11ea-896f-d4b87eb944d3.png)