### PR TITLE
DialogButton/ConfirmationDialog: Allow react nodes as title/description

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.0.3-beta.3",
+    "version": "1.0.3-beta.4",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/confirmation-dialog/ConfirmationDialog.jsx
+++ b/src/confirmation-dialog/ConfirmationDialog.jsx
@@ -6,8 +6,8 @@ import i18n from "../utils/i18n";
 class ConfirmationDialog extends React.Component {
     static propTypes = {
         isOpen: PropTypes.bool.isRequired,
-        title: PropTypes.string.isRequired,
-        description: PropTypes.string,
+        title: PropTypes.node.isRequired,
+        description: PropTypes.node,
         onSave: PropTypes.func,
         onCancel: PropTypes.func,
         saveText: PropTypes.string,
@@ -34,13 +34,7 @@ class ConfirmationDialog extends React.Component {
                 <DialogTitle>{title}</DialogTitle>
 
                 <DialogContent>
-                    {description && (
-                        <React.Fragment>
-                            {description.split("\n").map((text, idx) => (
-                                <p key={idx}>{text}</p>
-                            ))}
-                        </React.Fragment>
-                    )}
+                    {description && renderNode(description)}
                     {children}
                 </DialogContent>
 
@@ -58,6 +52,14 @@ class ConfirmationDialog extends React.Component {
                 </DialogActions>
             </Dialog>
         );
+    }
+}
+
+function renderNode(node) {
+    if (typeof node === "string") {
+        return node.split("\n").map((text, idx) => <p key={idx}>{text}</p>);
+    } else {
+        return node;
     }
 }
 

--- a/src/dialog-button/DialogButton.jsx
+++ b/src/dialog-button/DialogButton.jsx
@@ -6,8 +6,8 @@ import ConfirmationDialog from "../confirmation-dialog/ConfirmationDialog";
 class DialogButton extends React.Component {
     static propTypes = {
         buttonComponent: PropTypes.func.isRequired,
-        title: PropTypes.string.isRequired,
-        contents: PropTypes.string.isRequired,
+        title: PropTypes.node.isRequired,
+        contents: PropTypes.node.isRequired,
         initialIsOpen: PropTypes.bool,
         isVisible: PropTypes.bool,
     };


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/project-monitoring-app/pull/125