### PR TITLE
Feature/disable scroll lock context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.0.3-beta.3",
+    "version": "1.0.3-beta.5",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/data-table/ContextualMenu.tsx
+++ b/src/data-table/ContextualMenu.tsx
@@ -50,6 +50,7 @@ export function ContextualMenu<T extends ReferenceObject>(props: ContextualMenuP
             className={classes.root}
             open={isOpen}
             anchorReference="anchorPosition"
+            disableScrollLock={true}
             anchorPosition={{
                 left: positionLeft,
                 top: positionTop,


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/project-monitoring-app/pull/126

When the context menu is open, material-ui made some changes to the html/body to disable the overflow scrollbar. This moved some parts of the page to the right (ugly effect). 

See https://github.com/mui-org/material-ui/issues/17353