### PR TITLE
Add disable prop to TableSelection

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.0.3-beta.6",
+    "version": "1.0.3-beta.8",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/data-table/DataTableBody.tsx
+++ b/src/data-table/DataTableBody.tsx
@@ -113,8 +113,12 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
         };
 
         const selectedItem: Partial<TableSelection> = _.find(selected, { id: row.id });
-        const { checked = !!selectedItem, indeterminate = false, icon = <CheckBoxTwoToneIcon /> } =
-            selectedItem || {};
+        const {
+            checked = !!selectedItem,
+            indeterminate = false,
+            icon = <CheckBoxTwoToneIcon />,
+            disabled = false,
+        } = selectedItem || {};
 
         return (
             <React.Fragment key={`data-table-row-${index}`}>
@@ -134,6 +138,7 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
                                         checked={checked}
                                         indeterminate={indeterminate}
                                         indeterminateIcon={icon}
+                                        disabled={disabled}
                                     />
                                 )}
                                 {childrenRows.length > 0 && (

--- a/src/data-table/DataTableBody.tsx
+++ b/src/data-table/DataTableBody.tsx
@@ -31,6 +31,9 @@ const useStyles = makeStyles({
     childrenRow: {
         background: "#E0E0E0",
     },
+    disabledRow: {
+        backgroundColor: "#F5DFDF !important",
+    },
 });
 
 const rotateIconStyle = (isOpen: boolean) => ({
@@ -113,17 +116,18 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
         };
 
         const selectedItem: Partial<TableSelection> = _.find(selected, { id: row.id });
-        const {
-            checked = !!selectedItem,
-            indeterminate = false,
-            icon = <CheckBoxTwoToneIcon />,
-            disabled = false,
-        } = selectedItem || {};
+        const { checked = !!selectedItem, indeterminate = false, icon = <CheckBoxTwoToneIcon /> } =
+            selectedItem || {};
+        const isRowDisabled = row.selectable === false;
+        const rowClassName = _.compact([
+            level === 0 ? classes.bottomBorder : classes.childrenRow,
+            isRowDisabled ? classes.disabledRow : null,
+        ]).join(" ");
 
         return (
             <React.Fragment key={`data-table-row-${index}`}>
                 <TableRow
-                    className={level === 0 ? classes.bottomBorder : classes.childrenRow}
+                    className={rowClassName}
                     onClick={event => handleClick(event)}
                     onContextMenu={event => handleClick(event)}
                     role="checkbox"
@@ -138,7 +142,7 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
                                         checked={checked}
                                         indeterminate={indeterminate}
                                         indeterminateIcon={icon}
-                                        disabled={disabled}
+                                        disabled={isRowDisabled}
                                     />
                                 )}
                                 {childrenRows.length > 0 && (

--- a/src/data-table/types.ts
+++ b/src/data-table/types.ts
@@ -61,6 +61,7 @@ export interface TableSelection {
     checked?: boolean;
     indeterminate?: boolean;
     icon?: ReactNode;
+    disabled?: boolean;
 }
 
 export type ObjectsTableDetailField<T extends ReferenceObject> = Pick<

--- a/src/data-table/types.ts
+++ b/src/data-table/types.ts
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 
-export type ReferenceObject = { id: string };
+export type ReferenceObject = { id: string; selectable?: boolean };
 
 export interface TableObject extends ReferenceObject {
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
@@ -61,7 +61,6 @@ export interface TableSelection {
     checked?: boolean;
     indeterminate?: boolean;
     icon?: ReactNode;
-    disabled?: boolean;
 }
 
 export type ObjectsTableDetailField<T extends ReferenceObject> = Pick<


### PR DESCRIPTION
Fow now, the `disabled` property is used only for the checkbox. Should we also style the row?

![image](https://user-images.githubusercontent.com/24643/73362811-d17fb280-42a7-11ea-866c-3b2f23eb1018.png)
