### PR TITLE
Bump beta version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.0.3-beta.10",
+    "version": "1.0.3-beta.11",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {


### PR DESCRIPTION
Currently @beta-10 includes the disabled selection but not the changes to loading and breaks travis on ``metadata-sync``. Released beta 11 with current status of ``development`` that includes both changes.