### PR TITLE
Avoid infinite re-rendering when using inside a useEffect

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.0.3-beta.11",
+    "version": "1.0.3-beta.12",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.0.3-beta.12",
+    "version": "1.0.3-beta.13",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.0.3-beta.13",
+    "version": "1.0.3-beta.14",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/loading/LoadingProvider.tsx
+++ b/src/loading/LoadingProvider.tsx
@@ -32,14 +32,12 @@ export const LoadingProvider = ({ children }) => {
     };
 
     const value = {
+        ...state,
         show,
         hide,
         reset,
         updateMessage,
         updateProgress,
-        isLoading: state.isLoading,
-        message: state.message,
-        progress: state.progress,
     };
 
     return (

--- a/src/loading/index.tsx
+++ b/src/loading/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import loadingContext from "./context";
 import { LoadingState } from "./types";
 
@@ -15,5 +15,6 @@ export function withLoading(WrappedComponent: any) {
 
 export function useLoading() {
     const contextValue = useContext<LoadingState>(loadingContext);
-    return contextValue;
+    const [state] = useState(contextValue);
+    return state;
 }

--- a/src/loading/index.tsx
+++ b/src/loading/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useRef } from "react";
 import loadingContext from "./context";
 import { LoadingState } from "./types";
 
@@ -15,6 +15,6 @@ export function withLoading(WrappedComponent: any) {
 
 export function useLoading() {
     const contextValue = useContext<LoadingState>(loadingContext);
-    const [state] = useState(contextValue);
-    return state;
+    const ref = useRef(contextValue);
+    return ref.current;
 }

--- a/src/loading/types.ts
+++ b/src/loading/types.ts
@@ -4,13 +4,10 @@ export interface LoadingOptions {
     progress?: number;
 }
 
-export interface LoadingState {
+export interface LoadingState extends LoadingOptions {
     show: (isLoading?: boolean, message?: string, progress?: number) => void;
     hide: () => void;
     reset: () => void;
     updateMessage: (message: string) => void;
     updateProgress: (progress: number) => void;
-    isLoading: boolean;
-    message: string;
-    progress: number;
 }

--- a/src/snackbar/SnackbarConsumer.tsx
+++ b/src/snackbar/SnackbarConsumer.tsx
@@ -73,7 +73,7 @@ const SnackbarConsumer = props => {
 
     return (
         <SnackbarContext.Consumer>
-            {({ snackbarIsOpen, message, variant, closeSnackbar, autoHideDuration }) => {
+            {({ isOpen, message, variant, closeSnackbar, autoHideDuration }) => {
                 const Icon = variantIcon[variant];
                 if (!Icon) {
                     throw new Error(`Unknown variant: ${variant}`);
@@ -84,7 +84,7 @@ const SnackbarConsumer = props => {
                         <Snackbar
                             className={classes.root}
                             anchorOrigin={anchorOrigin}
-                            open={snackbarIsOpen}
+                            open={isOpen}
                             autoHideDuration={autoHideDuration}
                             onClose={closeSnackbar}
                         >

--- a/src/snackbar/SnackbarProvider.tsx
+++ b/src/snackbar/SnackbarProvider.tsx
@@ -50,13 +50,10 @@ export const SnackbarProvider = ({ children }) => {
     };
 
     const value = {
+        ...byLevel,
+        ...state,
         openSnackbar: openSnackbar,
-        byLevel: byLevel,
         closeSnackbar: closeSnackbar,
-        snackbarIsOpen: state.isOpen,
-        message: state.message,
-        variant: state.variant,
-        autoHideDuration: state.autoHideDuration,
     };
 
     return (

--- a/src/snackbar/index.tsx
+++ b/src/snackbar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import snackbarContext from "./context";
 import { SnackbarState } from "./types";
 
@@ -16,5 +16,6 @@ export function withSnackbar(WrappedComponent: any) {
 
 export function useSnackbar() {
     const contextValue = useContext<SnackbarState>(snackbarContext);
-    return contextValue.byLevel;
+    const [state] = useState(contextValue.byLevel);
+    return state;
 }

--- a/src/snackbar/index.tsx
+++ b/src/snackbar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useRef } from "react";
 import snackbarContext from "./context";
 import { SnackbarState } from "./types";
 
@@ -16,6 +16,6 @@ export function withSnackbar(WrappedComponent: any) {
 
 export function useSnackbar() {
     const contextValue = useContext<SnackbarState>(snackbarContext);
-    const [state] = useState(contextValue.byLevel);
-    return state;
+    const ref = useRef(contextValue);
+    return ref.current;
 }

--- a/src/snackbar/index.tsx
+++ b/src/snackbar/index.tsx
@@ -6,10 +6,9 @@ export function withSnackbar(WrappedComponent: any) {
     return class extends React.Component {
         static displayName = `withSnackbar${WrappedComponent.displayName}`;
         static contextType = snackbarContext;
-        openSnackbarByLevel = this.context.byLevel;
 
         render() {
-            return <WrappedComponent {...this.props} snackbar={this.openSnackbarByLevel} />;
+            return <WrappedComponent {...this.props} snackbar={this.context} />;
         }
     };
 }

--- a/src/snackbar/types.ts
+++ b/src/snackbar/types.ts
@@ -7,15 +7,14 @@ export interface SnackbarOptions {
     autoHideDuration?: number | null;
 }
 
-export interface SnackbarState extends SnackbarOptions {
-    success: (message: string, options?: Partial<SnackbarOptions>) => void;
-    info: (message: string, options?: Partial<SnackbarOptions>) => void;
-    warning: (message: string, options?: Partial<SnackbarOptions>) => void;
-    error: (message: string, options?: Partial<SnackbarOptions>) => void;
+export type SnackbarState = {
     openSnackbar: (
         variant: SnackbarLevel,
         message: string,
         options?: Partial<SnackbarOptions>
     ) => void;
     closeSnackbar: () => void;
-}
+} & {
+    [level in SnackbarLevel]: (message: string, options?: Partial<SnackbarOptions>) => void;
+} &
+    SnackbarOptions;

--- a/src/snackbar/types.ts
+++ b/src/snackbar/types.ts
@@ -7,21 +7,15 @@ export interface SnackbarOptions {
     autoHideDuration?: number | null;
 }
 
-export interface SnackbarState {
+export interface SnackbarState extends SnackbarOptions {
+    success: (message: string, options?: Partial<SnackbarOptions>) => void;
+    info: (message: string, options?: Partial<SnackbarOptions>) => void;
+    warning: (message: string, options?: Partial<SnackbarOptions>) => void;
+    error: (message: string, options?: Partial<SnackbarOptions>) => void;
     openSnackbar: (
         variant: SnackbarLevel,
         message: string,
         options?: Partial<SnackbarOptions>
     ) => void;
     closeSnackbar: () => void;
-    snackbarIsOpen: boolean;
-    message: string;
-    variant: SnackbarLevel;
-    autoHideDuration: number;
-    byLevel: {
-        success: (message: string, options?: Partial<SnackbarOptions>) => void;
-        info: (message: string, options?: Partial<SnackbarOptions>) => void;
-        warning: (message: string, options?: Partial<SnackbarOptions>) => void;
-        error: (message: string, options?: Partial<SnackbarOptions>) => void;
-    };
 }


### PR DESCRIPTION
# Implementation

- Store context inside a ref and return the immutable value
- Expose state and ``openSnackbar``/``closeSnackbar`` methods
- Unify code between ``useLoading`` and ``useSnackbar``