### PR TITLE
[DataTable] Allow overriding row styles from app

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.3.0-beta.3",
+    "version": "1.3.0-beta.4",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.3.0-beta.4",
+    "version": "1.3.0-beta.5",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.3.0-beta.2",
+    "version": "1.3.0-beta.3",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -10,19 +10,10 @@ import { DataTableBody } from "./DataTableBody";
 import { DataTableHeader } from "./DataTableHeader";
 import { DataTablePagination } from "./DataTablePagination";
 import {
-    MouseActionsMapping, ReferenceObject,
-
-
-
-
-
-
-
-
-
-
-
-    RowConfig, TableAction,
+    MouseActionsMapping,
+    ReferenceObject,
+    RowConfig,
+    TableAction,
     TableColumn,
     TableGlobalAction,
     TableInitialState,
@@ -31,7 +22,7 @@ import {
     TablePagination,
     TableSelection,
     TableSorting,
-    TableState
+    TableState,
 } from "./types";
 import { getActionRows, getSelectionMessages, parseActions } from "./utils/selection";
 import { sortObjects } from "./utils/sorting";

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -185,11 +185,18 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
     };
 
     const handleSelectAllClick = (event: React.ChangeEvent<HTMLInputElement>) => {
-        const ids = rowObjects.map(({ id }) => ({ id }));
-        const newSelection = event.target.checked
-            ? _.uniq(selection.concat(ids))
-            : _.differenceBy(selection, ids, "id");
-        handleSelectionChange(newSelection);
+        const ids = rowObjects
+            .filter(row => {
+                const { selectable = true } = rowConfig(row);
+                return selectable;
+            })
+            .map(({ id }) => ({ id }));
+
+        handleSelectionChange(
+            event.target.checked
+                ? _.uniq(selection.concat(ids))
+                : _.differenceBy(selection, ids, "id")
+        );
     };
 
     const handleCloseContextMenu = () => {

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -10,8 +10,19 @@ import { DataTableBody } from "./DataTableBody";
 import { DataTableHeader } from "./DataTableHeader";
 import { DataTablePagination } from "./DataTablePagination";
 import {
-    ReferenceObject,
-    TableAction,
+    MouseActionsMapping, ReferenceObject,
+
+
+
+
+
+
+
+
+
+
+
+    RowConfig, TableAction,
     TableColumn,
     TableGlobalAction,
     TableInitialState,
@@ -20,8 +31,7 @@ import {
     TablePagination,
     TableSelection,
     TableSorting,
-    TableState,
-    MouseActionsMapping,
+    TableState
 } from "./types";
 import { getActionRows, getSelectionMessages, parseActions } from "./utils/selection";
 import { sortObjects } from "./utils/sorting";
@@ -71,6 +81,7 @@ export interface DataTableProps<T extends ReferenceObject> {
     rows: T[];
     columns: TableColumn<T>[];
     actions?: TableAction<T>[];
+    rowConfig?(row: T): RowConfig;
     mouseActionsMapping?: MouseActionsMapping;
     globalActions?: TableGlobalAction[];
     initialState?: TableInitialState<T>;
@@ -97,6 +108,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
     const {
         rows,
         columns,
+        rowConfig,
         actions: availableActions = [],
         globalActions = [],
         initialState = {},
@@ -245,6 +257,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
                         <DataTableBody
                             rows={rowObjects}
                             columns={columns}
+                            rowConfig={rowConfig}
                             visibleColumns={visibleColumns}
                             sorting={sorting}
                             selected={selection}

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -24,6 +24,7 @@ import {
     TableSorting,
     TableState,
 } from "./types";
+import { defaultRowConfig } from "./utils/formatting";
 import { getActionRows, getSelectionMessages, parseActions } from "./utils/selection";
 import { sortObjects } from "./utils/sorting";
 
@@ -99,7 +100,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
     const {
         rows,
         columns,
-        rowConfig,
+        rowConfig = defaultRowConfig,
         actions: availableActions = [],
         globalActions = [],
         initialState = {},

--- a/src/data-table/DataTableBody.tsx
+++ b/src/data-table/DataTableBody.tsx
@@ -19,7 +19,7 @@ import {
     TableAction,
     TableColumn,
     TableSelection,
-    TableSorting
+    TableSorting,
 } from "./types";
 import { formatRowValue } from "./utils/formatting";
 import { isEventCtrlClick, parseActions, updateSelection } from "./utils/selection";

--- a/src/data-table/DataTableBody.tsx
+++ b/src/data-table/DataTableBody.tsx
@@ -55,8 +55,6 @@ const rotateIconStyle = (isOpen: boolean) => ({
     transform: isOpen ? "rotate(90deg)" : "none",
 });
 
-const defaultRowConfig = () => ({} as RowConfig);
-
 export interface DataTableBodyProps<T extends ReferenceObject> {
     rows: T[];
     columns: TableColumn<T>[];
@@ -77,7 +75,7 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
     const {
         rows,
         columns,
-        rowConfig = defaultRowConfig,
+        rowConfig,
         visibleColumns,
         sorting,
         availableActions,

--- a/src/data-table/types.ts
+++ b/src/data-table/types.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { CSSProperties, ReactNode } from "react";
 
 export type ReferenceObject = { id: string; selectable?: boolean };
 
@@ -23,6 +23,12 @@ export interface TableAction<T extends ReferenceObject> {
     primary?: boolean;
     onClick?(selectedIds: string[]): void;
     isActive?(rows: T[]): boolean;
+}
+
+export interface RowConfig {
+    style?: CSSProperties;
+    disabled?: boolean;
+    selectable?: boolean;
 }
 
 export type TableGlobalAction = Omit<TableAction<ReferenceObject>, "isActive">;

--- a/src/data-table/utils/formatting.tsx
+++ b/src/data-table/utils/formatting.tsx
@@ -1,8 +1,7 @@
-import React, { ReactNode } from "react";
-import moment from "moment";
 import _ from "lodash";
-
-import { TableColumn, ReferenceObject } from "../types";
+import moment from "moment";
+import React, { ReactNode } from "react";
+import { ReferenceObject, RowConfig, TableColumn } from "../types";
 
 const urlRegex = /https?:\/\/[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#()?&//=]*)/;
 
@@ -51,3 +50,5 @@ export function formatRowValue<T extends ReferenceObject>(
     const defaultValue = defaultFormatter(row[column.name]);
     return column.getValue ? column.getValue(row, defaultValue) : defaultValue;
 }
+
+export const defaultRowConfig = () => ({} as RowConfig);


### PR DESCRIPTION
New API: ``rowConfig?(row: T): RowConfig;``

RowConfig:

```
export interface RowConfig {
    style?: CSSProperties;
    disabled?: boolean;
    selectable?: boolean;
}
```

Usage example:

```
rowConfig={(_row: T) => ({
    style: { backgroundColor: "yellow"},
    disabled: true
})}
```

Behavior changes:

- Selectable: Disables the checkbox
- Disabled: Greys-out and disables pointer events (if selectable not set also disables the checkbox)
- Style: Overrides all pre-set styling in row (including changes applied by disabled/selectable)
