### PR TITLE
[OrgUnitsSelector] Fix selections from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.3.2-beta.1",
+    "version": "1.3.3-beta.1",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/org-unit-select/OrgUnitSelectAll.component.js
+++ b/src/org-unit-select/OrgUnitSelectAll.component.js
@@ -69,15 +69,14 @@ class OrgUnitSelectAll extends React.Component {
     }
 
     getDescendantOrgUnits() {
-        return this.context.api.models.organisationUnits
-            .get({
-                root: this.props.currentRoot.id,
+        return this.context.api
+            .get("/organisationUnits/" + this.props.currentRoot.id, {
                 paging: false,
                 includeDescendants: true,
-                fields: { id: true, path: true },
+                fields: "id,path",
             })
             .getData()
-            .then(({ objects }) => objects);
+            .then(({ organisationUnits }) => organisationUnits);
     }
 
     handleDeselectAll() {

--- a/src/org-unit-select/OrgUnitSelectByGroup.component.js
+++ b/src/org-unit-select/OrgUnitSelectByGroup.component.js
@@ -43,18 +43,14 @@ class OrgUnitSelectByGroup extends React.Component {
                 );
                 this.setState({ loading: true });
 
-                api.models.organisationUnits
-                    .get({
-                        root: this.props.currentRoot.id,
-                        paging: false,
-                        includeDescendants: true,
-                        fields: { id: true, path: true },
-                        filter: {
-                            "organisationUnitGroups.id": { eq: groupId },
-                        },
-                    })
+                api.get("/organisationUnits/" + this.props.currentRoot.id, {
+                    paging: false,
+                    includeDescendants: true,
+                    fields: "id,path",
+                    filter: `organisationUnitGroups.id:eq:${groupId}`,
+                })
                     .getData()
-                    .then(({ objects }) => objects)
+                    .then(({ organisationUnits }) => organisationUnits)
                     .then(orgUnits => {
                         log.debug(
                             `Loaded ${orgUnits.length} org units for group ${groupId} within ${this.props.currentRoot.displayName}`

--- a/src/org-unit-select/OrgUnitSelectByLevel.component.js
+++ b/src/org-unit-select/OrgUnitSelectByLevel.component.js
@@ -49,15 +49,13 @@ class OrgUnitSelectByLevel extends React.Component {
                     return resolve([]);
                 }
 
-                api.models.organisationUnits
-                    .get({
-                        paging: false,
-                        level: level - rootLevel,
-                        fields: { id: true, path: true },
-                        root: this.props.currentRoot.id,
-                    })
+                api.get("/organisationUnits/" + this.props.currentRoot.id, {
+                    paging: false,
+                    level: level - rootLevel,
+                    fields: "id,path",
+                })
                     .getData()
-                    .then(({ objects }) => objects)
+                    .then(({ organisationUnits }) => organisationUnits)
                     .then(orgUnitArray => {
                         log.debug(
                             `Loaded ${orgUnitArray.length} org units for level ` +


### PR DESCRIPTION
On d2, the component used `list({root: ID, ...}`, but it turns out this property is not passed in the query string but in the URL: `/organisationUnits/$root?...`. 

https://docs.dhis2.org/2.33/en/developer/html/webapi_organisation_units.html#webapi_list_of_organisation_units#webapi_organisation_units_with_relations

We don't support yet custom models as organisationUnits, so I am using directly `d2.api.get(...)`. I'll open an issue on d2-api -> https://github.com/EyeSeeTea/d2-api/issues/42