### PR TITLE
[OrgUnitTree] Allow filtering org unit tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.3.3",
+    "version": "1.3.3-beta.2",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.3.3-beta.2",
+    "version": "1.3.3-beta.4",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/org-unit-select/OrgUnitSelectAll.component.js
+++ b/src/org-unit-select/OrgUnitSelectAll.component.js
@@ -51,15 +51,12 @@ class OrgUnitSelectAll extends React.Component {
             this.context.api.models.organisationUnits
                 .get({ fields: { id: true, path: true }, paging: false })
                 .getData()
-                .then(({ objects }) => objects)
-                .then(orgUnits => {
-                    const ous = orgUnits.map(ou => ou.path);
+                .then(({ objects }) => {
+                    this.addToSelection(objects);
                     this.setState({
-                        cache: ous,
+                        cache: objects.map(ou => ou.path),
                         loading: false,
                     });
-
-                    this.props.onUpdateSelection(ous.slice());
                 })
                 .catch(err => {
                     this.setState({ loading: false });

--- a/src/org-unit-select/common.js
+++ b/src/org-unit-select/common.js
@@ -18,18 +18,16 @@ const style = {
 style.button1 = Object.assign({}, style.button, { marginLeft: 0 });
 
 function addToSelection(orgUnits) {
-    const orgUnitArray = Array.isArray(orgUnits) ? orgUnits : orgUnits.toArray();
-    const addedOus = orgUnitArray.filter(ou => !this.props.selected.includes(ou.path));
-    const filteredOus = this.props.filter
-        ? addedOus.filter(({ id }) => this.props.filter.includes(id))
-        : addedOus;
+    const { selectableIds, selected } = this.props;
+    const additions = orgUnits.filter(({ id }) =>
+        selectableIds ? selectableIds.includes(id) : true
+    );
 
-    this.props.onUpdateSelection(this.props.selected.concat(filteredOus.map(ou => ou.path)));
+    this.props.onUpdateSelection(_.uniq([...selected, ...additions.map(ou => ou.path)]));
 }
 
 function removeFromSelection(orgUnits) {
-    const orgUnitArray = Array.isArray(orgUnits) ? orgUnits : orgUnits.toArray();
-    const removedOus = orgUnitArray.filter(ou => this.props.selected.includes(ou.path));
+    const removedOus = orgUnits.filter(ou => this.props.selected.includes(ou.path));
     const removed = removedOus.map(ou => ou.path);
     const selectedOus = this.props.selected.filter(ou => !removed.includes(ou));
 

--- a/src/org-unit-select/common.js
+++ b/src/org-unit-select/common.js
@@ -91,5 +91,10 @@ function renderControls() {
     );
 }
 
-export { addToSelection, removeFromSelection, handleChangeSelection, renderDropdown, renderControls, };
-
+export {
+    addToSelection,
+    removeFromSelection,
+    handleChangeSelection,
+    renderDropdown,
+    renderControls,
+};

--- a/src/org-unit-select/common.js
+++ b/src/org-unit-select/common.js
@@ -20,9 +20,7 @@ style.button1 = Object.assign({}, style.button, { marginLeft: 0 });
 
 function addToSelection(orgUnits) {
     const { selectableIds, selected } = this.props;
-    const additions = orgUnits.filter(({ id }) =>
-        selectableIds ? selectableIds.includes(id) : true
-    );
+    const additions = orgUnits.filter(({ id }) => !selectableIds || selectableIds.includes(id));
     const newSelection = _.uniq([...selected, ...additions.map(ou => ou.path)]);
 
     this.props.onUpdateSelection(newSelection);

--- a/src/org-unit-select/common.js
+++ b/src/org-unit-select/common.js
@@ -1,6 +1,7 @@
-import React from "react";
+import { FormControl, InputLabel, LinearProgress, MenuItem, Select } from "@material-ui/core";
 import Button from "@material-ui/core/Button";
-import { LinearProgress, Select, MenuItem, FormControl, InputLabel } from "@material-ui/core";
+import _ from "lodash";
+import React from "react";
 import i18n from "../utils/i18n";
 
 const style = {
@@ -22,8 +23,9 @@ function addToSelection(orgUnits) {
     const additions = orgUnits.filter(({ id }) =>
         selectableIds ? selectableIds.includes(id) : true
     );
+    const newSelection = _.uniq([...selected, ...additions.map(ou => ou.path)]);
 
-    this.props.onUpdateSelection(_.uniq([...selected, ...additions.map(ou => ou.path)]));
+    this.props.onUpdateSelection(newSelection);
 }
 
 function removeFromSelection(orgUnits) {
@@ -89,10 +91,5 @@ function renderControls() {
     );
 }
 
-export {
-    addToSelection,
-    removeFromSelection,
-    handleChangeSelection,
-    renderDropdown,
-    renderControls,
-};
+export { addToSelection, removeFromSelection, handleChangeSelection, renderDropdown, renderControls, };
+

--- a/src/org-unit-select/common.js
+++ b/src/org-unit-select/common.js
@@ -20,8 +20,11 @@ style.button1 = Object.assign({}, style.button, { marginLeft: 0 });
 function addToSelection(orgUnits) {
     const orgUnitArray = Array.isArray(orgUnits) ? orgUnits : orgUnits.toArray();
     const addedOus = orgUnitArray.filter(ou => !this.props.selected.includes(ou.path));
+    const filteredOus = this.props.filter
+        ? addedOus.filter(({ id }) => this.props.filter.includes(id))
+        : addedOus;
 
-    this.props.onUpdateSelection(this.props.selected.concat(addedOus.map(ou => ou.path)));
+    this.props.onUpdateSelection(this.props.selected.concat(filteredOus.map(ou => ou.path)));
 }
 
 function removeFromSelection(orgUnits) {

--- a/src/org-unit-tree/OrgUnitTree.component.js
+++ b/src/org-unit-tree/OrgUnitTree.component.js
@@ -158,8 +158,7 @@ class OrgUnitTree extends React.Component {
                     onChildrenLoaded={this.props.onChildrenLoaded}
                     hideMemberCount={this.props.hideMemberCount}
                     orgUnitsPathsToInclude={this.props.orgUnitsPathsToInclude}
-                    disableTree={this.props.disableTree}
-                    filter={this.props.filter}
+                    selectableIds={this.props.selectableIds}
                 />
             );
         }
@@ -194,14 +193,13 @@ class OrgUnitTree extends React.Component {
             root: currentOu,
             selectableLevels,
             typeInput,
-            disableTree,
-            filter,
+            selectableIds,
             selected = [],
             hideCheckboxes,
         } = this.props;
 
         const maxSelectableLevel = Math.max(...selectableLevels);
-        const isExcluded = filter && !filter.includes(currentOu.id);
+        const isExcluded = selectableIds && !selectableIds.includes(currentOu.id);
         const isSelectable = !isExcluded && this.handleSelectableLevel(selectableLevels, currentOu);
         const pathRegEx = new RegExp(`/${currentOu.id}$`);
         const memberRegEx = new RegExp(`/${currentOu.id}`);
@@ -279,7 +277,7 @@ class OrgUnitTree extends React.Component {
             </div>
         );
 
-        if (!disableTree && hasChildren && currentOu.level !== maxSelectableLevel) {
+        if (hasChildren && currentOu.level !== maxSelectableLevel) {
             return (
                 <TreeView
                     label={label}
@@ -415,14 +413,9 @@ OrgUnitTree.propTypes = {
     orgUnitsPathsToInclude: PropTypes.array,
 
     /**
-     * if true, disable tree view for current roots
-     */
-    disableTree: PropTypes.bool,
-
-    /**
      * Array of org unit ids to filter checkbox selection
      */
-    filter: PropTypes.arrayOf(PropTypes.string),
+    selectableIds: PropTypes.arrayOf(PropTypes.string),
 };
 
 OrgUnitTree.defaultProps = {

--- a/src/org-unit-tree/OrgUnitTree.component.js
+++ b/src/org-unit-tree/OrgUnitTree.component.js
@@ -159,6 +159,7 @@ class OrgUnitTree extends React.Component {
                     hideMemberCount={this.props.hideMemberCount}
                     orgUnitsPathsToInclude={this.props.orgUnitsPathsToInclude}
                     disableTree={this.props.disableTree}
+                    filter={this.props.filter}
                 />
             );
         }
@@ -194,7 +195,9 @@ class OrgUnitTree extends React.Component {
             selectableLevels,
             typeInput,
             disableTree,
+            filter,
             selected = [],
+            hideCheckboxes,
         } = this.props;
 
         const maxSelectableLevel = Math.max(...selectableLevels);
@@ -257,9 +260,11 @@ class OrgUnitTree extends React.Component {
             ? this.handleSelectClick
             : (canBecomeCurrentRoot && setCurrentRoot) || (isSelectable && this.handleSelectClick);
 
+        const isExcluded = filter && !filter.includes(currentOu.id);
+
         const label = (
             <div style={labelStyle} onClick={onClick || undefined} role="button" tabIndex={0}>
-                {isSelectable && !this.props.hideCheckboxes && (
+                {isSelectable && !isExcluded && !hideCheckboxes && (
                     <input
                         type={handletypeInput}
                         readOnly
@@ -414,6 +419,11 @@ OrgUnitTree.propTypes = {
      * if true, disable tree view for current roots
      */
     disableTree: PropTypes.bool,
+
+    /**
+     * Array of org unit ids to filter checkbox selection
+     */
+    filter: PropTypes.arrayOf(PropTypes.string),
 };
 
 OrgUnitTree.defaultProps = {

--- a/src/org-unit-tree/OrgUnitTree.component.js
+++ b/src/org-unit-tree/OrgUnitTree.component.js
@@ -201,7 +201,8 @@ class OrgUnitTree extends React.Component {
         } = this.props;
 
         const maxSelectableLevel = Math.max(...selectableLevels);
-        const isSelectable = this.handleSelectableLevel(selectableLevels, currentOu);
+        const isExcluded = filter && !filter.includes(currentOu.id);
+        const isSelectable = !isExcluded && this.handleSelectableLevel(selectableLevels, currentOu);
         const pathRegEx = new RegExp(`/${currentOu.id}$`);
         const memberRegEx = new RegExp(`/${currentOu.id}`);
         const isSelected = selected.some(ou => pathRegEx.test(ou));
@@ -260,11 +261,9 @@ class OrgUnitTree extends React.Component {
             ? this.handleSelectClick
             : (canBecomeCurrentRoot && setCurrentRoot) || (isSelectable && this.handleSelectClick);
 
-        const isExcluded = filter && !filter.includes(currentOu.id);
-
         const label = (
             <div style={labelStyle} onClick={onClick || undefined} role="button" tabIndex={0}>
-                {isSelectable && !isExcluded && !hideCheckboxes && (
+                {isSelectable && !hideCheckboxes && (
                     <input
                         type={handletypeInput}
                         readOnly

--- a/src/org-unit-tree/OrgUnitTree.component.js
+++ b/src/org-unit-tree/OrgUnitTree.component.js
@@ -295,7 +295,7 @@ class OrgUnitTree extends React.Component {
 
         return (
             <div
-                onClick={isSelectable && this.handleSelectClick}
+                onClick={(isSelectable && this.handleSelectClick) || undefined}
                 className="orgunit without-children"
                 style={ouContainerStyle}
                 role="button"

--- a/src/org-unit-tree/OrgUnitTree.component.js
+++ b/src/org-unit-tree/OrgUnitTree.component.js
@@ -158,6 +158,7 @@ class OrgUnitTree extends React.Component {
                     onChildrenLoaded={this.props.onChildrenLoaded}
                     hideMemberCount={this.props.hideMemberCount}
                     orgUnitsPathsToInclude={this.props.orgUnitsPathsToInclude}
+                    disableTree={this.props.disableTree}
                 />
             );
         }
@@ -188,16 +189,19 @@ class OrgUnitTree extends React.Component {
     }
 
     render() {
-        const currentOu = this.props.root;
-        // True if a click handler exists
-        const selectableLevels = this.props.selectableLevels;
+        const {
+            root: currentOu,
+            selectableLevels,
+            typeInput,
+            disableTree,
+            selected = [],
+        } = this.props;
+
         const maxSelectableLevel = Math.max(...selectableLevels);
-        const typeInput = this.props.typeInput;
         const isSelectable = this.handleSelectableLevel(selectableLevels, currentOu);
         const pathRegEx = new RegExp(`/${currentOu.id}$`);
         const memberRegEx = new RegExp(`/${currentOu.id}`);
-        const isSelected =
-            this.props.selected && this.props.selected.some(ou => pathRegEx.test(ou));
+        const isSelected = selected.some(ou => pathRegEx.test(ou));
 
         // True if this OU has children = is not a leaf node
         const hasChildren =
@@ -271,7 +275,7 @@ class OrgUnitTree extends React.Component {
             </div>
         );
 
-        if (hasChildren && currentOu.level !== maxSelectableLevel) {
+        if (!disableTree && hasChildren && currentOu.level !== maxSelectableLevel) {
             return (
                 <TreeView
                     label={label}
@@ -405,6 +409,11 @@ OrgUnitTree.propTypes = {
      * Array of paths of Organisation Units to include on tree. If not defined or empty, all children from root to leafs will be shown
      */
     orgUnitsPathsToInclude: PropTypes.array,
+
+    /**
+     * if true, disable tree view for current roots
+     */
+    disableTree: PropTypes.bool,
 };
 
 OrgUnitTree.defaultProps = {

--- a/src/org-unit-tree/utils.js
+++ b/src/org-unit-tree/utils.js
@@ -22,14 +22,7 @@ export function forEachOnPath(root, path, op) {
  * @param orgUnit
  */
 export function decrementMemberCount(root, orgUnit) {
-    forEachOnPath(
-        root,
-        orgUnit.path
-            .substr(1)
-            .split("/")
-            .slice(1),
-        ou => ou.memberCount--
-    );
+    forEachOnPath(root, orgUnit.path.substr(1).split("/").slice(1), ou => ou.memberCount--);
 }
 
 /**
@@ -39,14 +32,7 @@ export function decrementMemberCount(root, orgUnit) {
  * @param orgUnit
  */
 export function incrementMemberCount(root, orgUnit) {
-    forEachOnPath(
-        root,
-        orgUnit.path
-            .substr(1)
-            .split("/")
-            .slice(1),
-        ou => ou.memberCount++
-    );
+    forEachOnPath(root, orgUnit.path.substr(1).split("/").slice(1), ou => ou.memberCount++);
 }
 
 /**
@@ -64,10 +50,7 @@ export function mergeChildren(root, children) {
         return root;
     }
 
-    const childPath = children
-        .toArray()[0]
-        .path.substr(1)
-        .split("/");
+    const childPath = children.toArray()[0].path.substr(1).split("/");
     childPath.splice(-1, 1);
     return assignChildren(root, childPath.slice(1), children);
 }

--- a/src/org-unit-tree/utils.js
+++ b/src/org-unit-tree/utils.js
@@ -22,7 +22,14 @@ export function forEachOnPath(root, path, op) {
  * @param orgUnit
  */
 export function decrementMemberCount(root, orgUnit) {
-    forEachOnPath(root, orgUnit.path.substr(1).split("/").slice(1), ou => ou.memberCount--);
+    forEachOnPath(
+        root,
+        orgUnit.path
+            .substr(1)
+            .split("/")
+            .slice(1),
+        ou => ou.memberCount--
+    );
 }
 
 /**
@@ -32,7 +39,14 @@ export function decrementMemberCount(root, orgUnit) {
  * @param orgUnit
  */
 export function incrementMemberCount(root, orgUnit) {
-    forEachOnPath(root, orgUnit.path.substr(1).split("/").slice(1), ou => ou.memberCount++);
+    forEachOnPath(
+        root,
+        orgUnit.path
+            .substr(1)
+            .split("/")
+            .slice(1),
+        ou => ou.memberCount++
+    );
 }
 
 /**
@@ -50,7 +64,10 @@ export function mergeChildren(root, children) {
         return root;
     }
 
-    const childPath = children.toArray()[0].path.substr(1).split("/");
+    const childPath = children
+        .toArray()[0]
+        .path.substr(1)
+        .split("/");
     childPath.splice(-1, 1);
     return assignChildren(root, childPath.slice(1), children);
 }

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -31,6 +31,7 @@ export default class OrgUnitsSelector extends React.Component {
         square: PropTypes.bool,
         singleSelection: PropTypes.bool,
         disableTree: PropTypes.bool,
+        filter: PropTypes.arrayOf(PropTypes.string),
     };
 
     static defaultProps = {
@@ -47,6 +48,7 @@ export default class OrgUnitsSelector extends React.Component {
         square: false,
         singleSelection: false,
         disableTree: false,
+        filter: undefined,
     };
 
     static childContextTypes = {
@@ -237,6 +239,7 @@ export default class OrgUnitsSelector extends React.Component {
             square,
             selectOnClick,
             disableTree,
+            filter,
             initiallyExpanded = roots.length > 1 ? [] : roots.map(ou => ou.path),
         } = this.props;
         const { filterByLevel, filterByGroup, selectAll } = controls;
@@ -284,6 +287,7 @@ export default class OrgUnitsSelector extends React.Component {
                                         hideMemberCount={hideMemberCount}
                                         selectOnClick={selectOnClick}
                                         disableTree={disableTree}
+                                        filter={filter}
                                     />
                                 </div>
                             ))}
@@ -302,6 +306,7 @@ export default class OrgUnitsSelector extends React.Component {
                                                     selected={selected}
                                                     currentRoot={currentRoot}
                                                     onUpdateSelection={this.handleSelectionUpdate}
+                                                    filter={filter}
                                                 />
                                             </div>
                                         )}
@@ -313,6 +318,7 @@ export default class OrgUnitsSelector extends React.Component {
                                                     selected={selected}
                                                     currentRoot={currentRoot}
                                                     onUpdateSelection={this.handleSelectionUpdate}
+                                                    filter={filter}
                                                 />
                                             </div>
                                         )}
@@ -325,6 +331,7 @@ export default class OrgUnitsSelector extends React.Component {
                                             selected={selected}
                                             currentRoot={currentRoot}
                                             onUpdateSelection={this.handleSelectionUpdate}
+                                            filter={filter}
                                         />
                                     </div>
                                 )}
@@ -360,7 +367,9 @@ function mergeChildren(root, children) {
     if (children.length === 0) {
         return root;
     } else {
-        const childPath = _.first(children).path.slice(1).split("/");
+        const childPath = _.first(children)
+            .path.slice(1)
+            .split("/");
         const parentPath = childPath.slice(0, childPath.length - 1);
         return assignChildren(root, parentPath, children);
     }

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -103,7 +103,7 @@ export default class OrgUnitsSelector extends React.Component {
     }
 
     queryRoots({ search }) {
-        const { api, rootIds } = this.props;
+        const { api, rootIds, listParams } = this.props;
         const baseOptions = {
             fields: {
                 id: true,
@@ -112,6 +112,7 @@ export default class OrgUnitsSelector extends React.Component {
                 path: true,
                 children: true,
             },
+            ...listParams,
         };
 
         if (search) {

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -2,11 +2,11 @@ import { Card, CardContent } from "@material-ui/core";
 import _ from "lodash";
 import PropTypes from "prop-types";
 import React from "react";
-import { promiseMap } from "../../../utils/common";
 import { OrgUnitSelectAll, OrgUnitSelectByGroup, OrgUnitSelectByLevel } from "../org-unit-select";
 import { decrementMemberCount, incrementMemberCount, OrgUnitTree } from "../org-unit-tree";
 import SearchBox from "../search-box/SearchBox";
 import i18n from "../utils/i18n";
+import { promiseMap } from "../utils/promiseMap";
 
 // Base code taken from d2-ui/examples/create-react-app/src/components/org-unit-selector.js
 

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -29,6 +29,7 @@ export default class OrgUnitsSelector extends React.Component {
         fullWidth: PropTypes.bool,
         square: PropTypes.bool,
         singleSelection: PropTypes.bool,
+        disableTree: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -44,6 +45,7 @@ export default class OrgUnitsSelector extends React.Component {
         fullWidth: true,
         square: false,
         singleSelection: false,
+        disableTree: false,
     };
 
     static childContextTypes = {
@@ -222,6 +224,7 @@ export default class OrgUnitsSelector extends React.Component {
             fullWidth,
             square,
             selectOnClick,
+            disableTree,
             initiallyExpanded = roots.length > 1 ? [] : roots.map(ou => ou.path),
         } = this.props;
         const { filterByLevel, filterByGroup, selectAll } = controls;
@@ -268,6 +271,7 @@ export default class OrgUnitsSelector extends React.Component {
                                         hideCheckboxes={hideCheckboxes}
                                         hideMemberCount={hideMemberCount}
                                         selectOnClick={selectOnClick}
+                                        disableTree={disableTree}
                                     />
                                 </div>
                             ))}
@@ -344,9 +348,7 @@ function mergeChildren(root, children) {
     if (children.length === 0) {
         return root;
     } else {
-        const childPath = _.first(children)
-            .path.slice(1)
-            .split("/");
+        const childPath = _.first(children).path.slice(1).split("/");
         const parentPath = childPath.slice(0, childPath.length - 1);
         return assignChildren(root, parentPath, children);
     }

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -30,8 +30,7 @@ export default class OrgUnitsSelector extends React.Component {
         fullWidth: PropTypes.bool,
         square: PropTypes.bool,
         singleSelection: PropTypes.bool,
-        disableTree: PropTypes.bool,
-        filter: PropTypes.arrayOf(PropTypes.string),
+        selectableIds: PropTypes.arrayOf(PropTypes.string),
     };
 
     static defaultProps = {
@@ -47,8 +46,7 @@ export default class OrgUnitsSelector extends React.Component {
         fullWidth: true,
         square: false,
         singleSelection: false,
-        disableTree: false,
-        filter: undefined,
+        selectableIds: undefined,
     };
 
     static childContextTypes = {
@@ -238,8 +236,7 @@ export default class OrgUnitsSelector extends React.Component {
             fullWidth,
             square,
             selectOnClick,
-            disableTree,
-            filter,
+            selectableIds,
             initiallyExpanded = roots.length > 1 ? [] : roots.map(ou => ou.path),
         } = this.props;
         const { filterByLevel, filterByGroup, selectAll } = controls;
@@ -286,8 +283,7 @@ export default class OrgUnitsSelector extends React.Component {
                                         hideCheckboxes={hideCheckboxes}
                                         hideMemberCount={hideMemberCount}
                                         selectOnClick={selectOnClick}
-                                        disableTree={disableTree}
-                                        filter={filter}
+                                        selectableIds={selectableIds}
                                     />
                                 </div>
                             ))}
@@ -306,7 +302,7 @@ export default class OrgUnitsSelector extends React.Component {
                                                     selected={selected}
                                                     currentRoot={currentRoot}
                                                     onUpdateSelection={this.handleSelectionUpdate}
-                                                    filter={filter}
+                                                    selectableIds={selectableIds}
                                                 />
                                             </div>
                                         )}
@@ -318,7 +314,7 @@ export default class OrgUnitsSelector extends React.Component {
                                                     selected={selected}
                                                     currentRoot={currentRoot}
                                                     onUpdateSelection={this.handleSelectionUpdate}
-                                                    filter={filter}
+                                                    selectableIds={selectableIds}
                                                 />
                                             </div>
                                         )}
@@ -331,7 +327,7 @@ export default class OrgUnitsSelector extends React.Component {
                                             selected={selected}
                                             currentRoot={currentRoot}
                                             onUpdateSelection={this.handleSelectionUpdate}
-                                            filter={filter}
+                                            selectableIds={selectableIds}
                                         />
                                     </div>
                                 )}

--- a/src/utils/promiseMap.ts
+++ b/src/utils/promiseMap.ts
@@ -1,0 +1,11 @@
+/* Map sequentially over T[] with an asynchronous function and return array of mapped values */
+export function promiseMap<T, S>(inputValues: T[], mapper: (value: T) => Promise<S>): Promise<S[]> {
+    const reducer = (acc$: Promise<S[]>, inputValue: T): Promise<S[]> =>
+        acc$.then((acc: S[]) =>
+            mapper(inputValue).then(result => {
+                acc.push(result);
+                return acc;
+            })
+        );
+    return inputValues.reduce(reducer, Promise.resolve([]));
+}


### PR DESCRIPTION
### Implementation

- Add new property ``selectableIds`` to filter which organisations in the tree can be selected (either by checkbox or double click)

- Fix 414 error when passing thousands of roots to the tree

- Adapt Select All, Select by Group and Select by Level to be filtered by ``selectableIds`` if provided

### Others

- We should migrate these components (or at least ``OrgUnitsSelector`` to TS and functional components)

- I would add some changes to ``loading`` and ``error`` catching so that the UX is better when working with large OU trees (such as WHO's)