### PR TITLE
[ConfirmationDialog] Add additional help or info button

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,13 +5,16 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-03-04T21:03:33.295Z\n"
-"PO-Revision-Date: 2020-03-04T21:03:33.295Z\n"
+"POT-Creation-Date: 2020-05-20T17:17:06.740Z\n"
+"PO-Revision-Date: 2020-05-20T17:17:06.740Z\n"
 
 msgid "Cancel"
 msgstr ""
 
 msgid "Save"
+msgstr ""
+
+msgid "Info"
 msgstr ""
 
 msgid "Columns to show in table"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2020-03-04T21:03:33.295Z\n"
+"POT-Creation-Date: 2020-05-20T17:17:06.740Z\n"
 "PO-Revision-Date: 2019-02-14T11:21:26.165Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -13,6 +13,9 @@ msgstr "Cancelar"
 
 msgid "Save"
 msgstr "Guardar"
+
+msgid "Info"
+msgstr ""
 
 msgid "Columns to show in table"
 msgstr "Columnas a mostrar en la tabla"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -15,7 +15,7 @@ msgid "Save"
 msgstr "Guardar"
 
 msgid "Info"
-msgstr ""
+msgstr "Información"
 
 msgid "Columns to show in table"
 msgstr "Columnas a mostrar en la tabla"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -15,7 +15,7 @@ msgid "Save"
 msgstr "Enregistrer"
 
 msgid "Info"
-msgstr ""
+msgstr "Info"
 
 msgid "Columns to show in table"
 msgstr ""

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2020-03-04T21:03:33.295Z\n"
+"POT-Creation-Date: 2020-05-20T17:17:06.740Z\n"
 "PO-Revision-Date: 2019-02-14T11:21:26.165Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -13,6 +13,9 @@ msgstr "Annuler"
 
 msgid "Save"
 msgstr "Enregistrer"
+
+msgid "Info"
+msgstr ""
 
 msgid "Columns to show in table"
 msgstr ""

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.3.3-beta.2",
+    "version": "1.3.3-beta.3",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/confirmation-dialog/ConfirmationDialog.tsx
+++ b/src/confirmation-dialog/ConfirmationDialog.tsx
@@ -5,6 +5,7 @@ import {
     DialogContent,
     DialogProps,
     DialogTitle,
+    makeStyles,
 } from "@material-ui/core";
 import _ from "lodash";
 import React, { ReactNode } from "react";
@@ -16,8 +17,10 @@ export interface ConfirmationDialogProps extends Partial<DialogProps> {
     description?: string | ReactNode;
     onSave?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
     onCancel?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+    onInfoAction?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
     saveText?: string;
     cancelText?: string;
+    infoActionText?: string;
     disableSave?: boolean;
 }
 
@@ -26,13 +29,17 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
     description,
     onSave,
     onCancel,
+    onInfoAction,
     isOpen = false,
     children,
     cancelText = i18n.t("Cancel"),
     saveText = i18n.t("Save"),
+    infoActionText = i18n.t("Info"),
     disableSave = false,
     ...other
 }) => {
+    const classes = useStyles();
+
     return (
         <Dialog open={isOpen} onClose={onCancel || _.noop} {...other}>
             <DialogTitle>{title}</DialogTitle>
@@ -43,6 +50,16 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
             </DialogContent>
 
             <DialogActions>
+                {onInfoAction && (
+                    <Button
+                        key={"info"}
+                        className={classes.infoButton}
+                        onClick={onInfoAction}
+                        autoFocus
+                    >
+                        {infoActionText}
+                    </Button>
+                )}
                 {onCancel && (
                     <Button key={"cancel"} onClick={onCancel} autoFocus>
                         {cancelText}
@@ -65,5 +82,9 @@ function renderNode(node: ReactNode) {
         return node;
     }
 }
+
+const useStyles = makeStyles({
+    infoButton: { marginRight: "auto" },
+});
 
 export default ConfirmationDialog;


### PR DESCRIPTION
- In Bulk-Load we will show a third button in the confirmation dialog.
- This is commonly known as ``help`` or ``info`` button and is placed at the bottom left corner

![image](https://user-images.githubusercontent.com/2181866/82527721-6ea47680-9b37-11ea-916e-f7076b73d38f.png)
