### PR TITLE
[Proposal] Add new useConfirmationDialog hook

### DIFF
--- a/src/confirmation-dialog/useConfirmationDialog.tsx
+++ b/src/confirmation-dialog/useConfirmationDialog.tsx
@@ -2,10 +2,18 @@ import React, { useCallback, useState } from "react";
 import { ConfirmationDialog, ConfirmationDialogProps } from "./ConfirmationDialog";
 
 export interface ConfirmationDialogHookState extends Omit<ConfirmationDialogProps, "isOpen"> {
-    autoClose: boolean;
+    autoClose?: boolean;
 }
 
-export function useConfirmationDialog(initialState: ConfirmationDialogHookState | null = null) {
+export type ConfirmationDialogHookResult = [
+    (props: ConfirmationDialogProps) => JSX.Element | null,
+    (state: ConfirmationDialogHookState) => void,
+    () => void
+];
+
+export function useConfirmationDialog(
+    initialState: ConfirmationDialogHookState | null = null
+): ConfirmationDialogHookResult {
     const [modalState, updateModal] = useState<ConfirmationDialogHookState | null>(initialState);
     const closeModal = useCallback(() => updateModal(null), []);
 

--- a/src/confirmation-dialog/useConfirmationDialog.tsx
+++ b/src/confirmation-dialog/useConfirmationDialog.tsx
@@ -1,0 +1,43 @@
+import React, { useCallback, useState } from "react";
+import { ConfirmationDialog, ConfirmationDialogProps } from "./ConfirmationDialog";
+
+export interface ConfirmationDialogHookState extends Omit<ConfirmationDialogProps, "isOpen"> {
+    autoClose: boolean;
+}
+
+export function useConfirmationDialog(initialState: ConfirmationDialogHookState | null = null) {
+    const [modalState, updateModal] = useState<ConfirmationDialogHookState | null>(initialState);
+    const closeModal = useCallback(() => updateModal(null), []);
+
+    const component = useCallback(
+        (props: ConfirmationDialogProps) => {
+            if (modalState === null) return null;
+            const { autoClose = true, onSave, onCancel, onInfoAction, ...rest } = modalState;
+
+            return (
+                <ConfirmationDialog
+                    {...props}
+                    {...rest}
+                    isOpen={true}
+                    onSave={event => {
+                        if (onSave) onSave(event);
+                        if (autoClose) closeModal();
+                    }}
+                    onCancel={event => {
+                        if (onCancel) onCancel(event);
+                        if (autoClose) closeModal();
+                    }}
+                    onInfoAction={event => {
+                        if (onInfoAction) onInfoAction(event);
+                        if (autoClose) closeModal();
+                    }}
+                />
+            );
+        },
+        [closeModal, modalState]
+    );
+
+    return [component, updateModal, closeModal];
+}
+
+export default useConfirmationDialog;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import SimpleCheckBox from "./simple-check-box/SimpleCheckBox";
 import "./locales";
 
 export * from "./confirmation-dialog/ConfirmationDialog";
+export * from "./confirmation-dialog/useConfirmationDialog";
 export * from "./data-table/DataTable";
 export * from "./data-table/ObjectsTable";
 export * from "./data-table/types";


### PR DESCRIPTION
Since we tend to have multiple dialogs in the same page, I'd like to propose a new API in d2-ui-components like this. I believe we already discussed this idea in the past, and I have a similar helper method in metadata-sync.

Example usage:

```ts
export function Component() {
    const [ModalComponent, updateModal, closeModal] = useModal(optionalInitialState);

    const onButtonClick = () => {
        updateModal({
            title: "Overwrite existing data values",
            description: "Are you sure?",
            onSave: () => performImport(info),
            onInfoAction: () => performImport(info, false),
            saveText: "Proceed",
            cancelText: "Cancel",
            infoActionText: "Import only new data values",
        });
    };

    return (
        <React.Fragment>
            <Button onClick={onButtonClick}>Import data</Button>
            <ModalComponent {...optionalSharedProps} />
        </React.Fragment>
    );
}
```