### PR TITLE
[DataTable] Move page size options to parent

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.4.3-beta.3",
+    "version": "1.4.3-beta.4",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.5.1-beta.1",
+    "version": "1.5.1-beta.2",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.4.3-beta.2",
+    "version": "1.4.3-beta.3",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.4.3-beta.1",
+    "version": "1.4.3-beta.2",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -143,6 +143,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
     const sorting = controlledSorting || stateSorting;
     const selection = controlledSelection || stateSelection;
     const pagination = {
+        pageSize: 25,
         total: undefined,
         page: 1,
         ...statePagination,

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -91,7 +91,6 @@ export interface DataTableProps<T extends ReferenceObject> {
     sorting?: TableSorting<T>;
     selection?: TableSelection[];
     pagination?: Partial<TablePagination>;
-    pageSize?: number;
     pageSizeOptions?: number[];
     onChange?(state: TableState<T>): void;
     resetKey?: string;
@@ -119,7 +118,6 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
         sorting: controlledSorting,
         selection: controlledSelection,
         pagination: controlledPagination,
-        pageSize = 25,
         pageSizeOptions = [10, 25, 50, 100],
         onChange = _.noop,
         resetKey,
@@ -153,7 +151,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
 
     const rowObjects = controlledPagination
         ? rows
-        : sortObjects(rows, columns, pageSize, pagination, sorting);
+        : sortObjects(rows, columns, pagination, sorting);
     const selectableRows = React.useMemo(() => {
         return rowObjects.filter(row => row.selectable !== false);
     }, [rowObjects]);
@@ -231,7 +229,6 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
                     {loading && <CircularProgress size={30} className={classes.loading} />}
                     <div className={classes.paginator}>
                         <DataTablePagination
-                            pageSize={pageSize}
                             pageSizeOptions={pageSizeOptions}
                             pagination={pagination}
                             defaultTotal={rows.length}

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -11,6 +11,7 @@ import { DataTableHeader } from "./DataTableHeader";
 import { DataTablePagination } from "./DataTablePagination";
 import {
     MouseActionsMapping,
+    PaginationOptions,
     ReferenceObject,
     RowConfig,
     TableAction,
@@ -91,7 +92,7 @@ export interface DataTableProps<T extends ReferenceObject> {
     sorting?: TableSorting<T>;
     selection?: TableSelection[];
     pagination?: Partial<TablePagination>;
-    pageSizeOptions?: number[];
+    paginationOptions?: PaginationOptions;
     onChange?(state: TableState<T>): void;
     resetKey?: string;
 }
@@ -118,7 +119,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
         sorting: controlledSorting,
         selection: controlledSelection,
         pagination: controlledPagination,
-        pageSizeOptions = [10, 25, 50, 100],
+        paginationOptions = {} as PaginationOptions,
         onChange = _.noop,
         resetKey,
         mouseActionsMapping,
@@ -140,8 +141,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
         updateVisibleColumns(visibleColumns => _.uniq([...visibleColumns, ...newVisibleColumns]));
     }, [columns]);
 
-    const pageSize = pageSizeOptions.includes(25) ? 25 : pageSizeOptions[0];
-    if (!pageSize) throw new Error("Invalid page size options");
+    const { pageSizeInitialValue: pageSize = 25 } = paginationOptions;
 
     const sorting = controlledSorting || stateSorting;
     const selection = controlledSelection || stateSelection;
@@ -233,7 +233,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
                     {loading && <CircularProgress size={30} className={classes.loading} />}
                     <div className={classes.paginator}>
                         <DataTablePagination
-                            pageSizeOptions={pageSizeOptions}
+                            paginationOptions={paginationOptions}
                             pagination={pagination}
                             defaultTotal={rows.length}
                             onChange={handlePaginationChange}

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -92,7 +92,7 @@ export interface DataTableProps<T extends ReferenceObject> {
     sorting?: TableSorting<T>;
     selection?: TableSelection[];
     pagination?: Partial<TablePagination>;
-    paginationOptions?: PaginationOptions;
+    paginationOptions?: Partial<PaginationOptions>;
     onChange?(state: TableState<T>): void;
     resetKey?: string;
 }
@@ -119,7 +119,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
         sorting: controlledSorting,
         selection: controlledSelection,
         pagination: controlledPagination,
-        paginationOptions = {} as PaginationOptions,
+        paginationOptions = {},
         onChange = _.noop,
         resetKey,
         mouseActionsMapping,

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -140,10 +140,13 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
         updateVisibleColumns(visibleColumns => _.uniq([...visibleColumns, ...newVisibleColumns]));
     }, [columns]);
 
+    const pageSize = pageSizeOptions.includes(25) ? 25 : pageSizeOptions[0];
+    if (!pageSize) throw new Error("Invalid page size options");
+
     const sorting = controlledSorting || stateSorting;
     const selection = controlledSelection || stateSelection;
     const pagination = {
-        pageSize: 25,
+        pageSize,
         total: undefined,
         page: 1,
         ...statePagination,

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -153,7 +153,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
 
     const rowObjects = controlledPagination
         ? rows
-        : sortObjects(rows, columns, pagination, sorting);
+        : sortObjects(rows, columns, pageSize, pagination, sorting);
     const selectableRows = React.useMemo(() => {
         return rowObjects.filter(row => row.selectable !== false);
     }, [rowObjects]);

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -91,6 +91,8 @@ export interface DataTableProps<T extends ReferenceObject> {
     sorting?: TableSorting<T>;
     selection?: TableSelection[];
     pagination?: Partial<TablePagination>;
+    pageSize?: number;
+    pageSizeOptions?: number[];
     onChange?(state: TableState<T>): void;
     resetKey?: string;
 }
@@ -117,6 +119,8 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
         sorting: controlledSorting,
         selection: controlledSelection,
         pagination: controlledPagination,
+        pageSize = 25,
+        pageSizeOptions = [10, 25, 50, 100],
         onChange = _.noop,
         resetKey,
         mouseActionsMapping,
@@ -141,10 +145,8 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
     const sorting = controlledSorting || stateSorting;
     const selection = controlledSelection || stateSelection;
     const pagination = {
-        pageSize: 25,
         total: undefined,
         page: 1,
-        pageSizeOptions: [10, 25, 50, 100],
         ...statePagination,
         ...controlledPagination,
     };
@@ -229,6 +231,8 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
                     {loading && <CircularProgress size={30} className={classes.loading} />}
                     <div className={classes.paginator}>
                         <DataTablePagination
+                            pageSize={pageSize}
+                            pageSizeOptions={pageSizeOptions}
                             pagination={pagination}
                             defaultTotal={rows.length}
                             onChange={handlePaginationChange}

--- a/src/data-table/DataTablePagination.tsx
+++ b/src/data-table/DataTablePagination.tsx
@@ -1,18 +1,18 @@
-import React from "react";
-import _ from "lodash";
 import Pagination from "@material-ui/core/TablePagination";
-
-import { TablePagination } from "./types";
+import _ from "lodash";
+import React from "react";
+import { PaginationOptions, TablePagination } from "./types";
 
 export interface DataTablePaginationProps {
     pagination: TablePagination;
-    pageSizeOptions: number[];
+    paginationOptions: PaginationOptions;
     defaultTotal: number;
     onChange?(newPagination: TablePagination): void;
 }
 
 export function DataTablePagination(props: DataTablePaginationProps) {
-    const { pagination, pageSizeOptions, onChange = _.noop, defaultTotal } = props;
+    const { pagination, paginationOptions, onChange = _.noop, defaultTotal } = props;
+    const { pageSizeOptions = [10, 25, 50, 100] } = paginationOptions;
     const { page, pageSize, total = defaultTotal } = pagination;
 
     const handleChangePage = (_event: unknown, page: number) => {

--- a/src/data-table/DataTablePagination.tsx
+++ b/src/data-table/DataTablePagination.tsx
@@ -6,13 +6,15 @@ import { TablePagination } from "./types";
 
 export interface DataTablePaginationProps {
     pagination: TablePagination;
+    pageSize: number;
+    pageSizeOptions: number[];
     defaultTotal: number;
     onChange?(newPagination: TablePagination): void;
 }
 
 export function DataTablePagination(props: DataTablePaginationProps) {
-    const { pagination, onChange = _.noop, defaultTotal } = props;
-    const { page, pageSize, pageSizeOptions, total = defaultTotal } = pagination;
+    const { pagination, pageSizeOptions, pageSize, onChange = _.noop, defaultTotal } = props;
+    const { page, total = defaultTotal } = pagination;
 
     const handleChangePage = (_event: unknown, page: number) => {
         onChange({

--- a/src/data-table/DataTablePagination.tsx
+++ b/src/data-table/DataTablePagination.tsx
@@ -5,7 +5,7 @@ import { PaginationOptions, TablePagination } from "./types";
 
 export interface DataTablePaginationProps {
     pagination: TablePagination;
-    paginationOptions: PaginationOptions;
+    paginationOptions: Partial<PaginationOptions>;
     defaultTotal: number;
     onChange?(newPagination: TablePagination): void;
 }

--- a/src/data-table/DataTablePagination.tsx
+++ b/src/data-table/DataTablePagination.tsx
@@ -6,15 +6,14 @@ import { TablePagination } from "./types";
 
 export interface DataTablePaginationProps {
     pagination: TablePagination;
-    pageSize: number;
     pageSizeOptions: number[];
     defaultTotal: number;
     onChange?(newPagination: TablePagination): void;
 }
 
 export function DataTablePagination(props: DataTablePaginationProps) {
-    const { pagination, pageSizeOptions, pageSize, onChange = _.noop, defaultTotal } = props;
-    const { page, total = defaultTotal } = pagination;
+    const { pagination, pageSizeOptions, onChange = _.noop, defaultTotal } = props;
+    const { page, pageSize, total = defaultTotal } = pagination;
 
     const handleChangePage = (_event: unknown, page: number) => {
         onChange({

--- a/src/data-table/types.ts
+++ b/src/data-table/types.ts
@@ -39,8 +39,6 @@ export interface TableSorting<T extends ReferenceObject> {
 }
 
 export interface TablePagination {
-    pageSize: number;
-    pageSizeOptions: number[];
     total: number;
     page: number;
 }

--- a/src/data-table/types.ts
+++ b/src/data-table/types.ts
@@ -39,6 +39,7 @@ export interface TableSorting<T extends ReferenceObject> {
 }
 
 export interface TablePagination {
+    pageSize: number;
     total: number;
     page: number;
 }

--- a/src/data-table/types.ts
+++ b/src/data-table/types.ts
@@ -81,3 +81,8 @@ export type MouseActionMapping =
     | { type: "action"; action: string };
 
 export type MouseActionsMapping = Record<"left" | "right", MouseActionMapping>;
+
+export interface PaginationOptions {
+    pageSizeOptions: number[];
+    pageSizeInitialValue: number;
+}

--- a/src/data-table/utils/sorting.tsx
+++ b/src/data-table/utils/sorting.tsx
@@ -6,11 +6,12 @@ import { ReactNode } from "react";
 export function sortObjects<T extends ReferenceObject>(
     rows: T[],
     columns: TableColumn<T>[],
+    pageSize: number,
     tablePagination: TablePagination,
     tableSorting: TableSorting<T>
 ) {
     const { field, order } = tableSorting;
-    const { page, pageSize } = tablePagination;
+    const { page } = tablePagination;
     const column = columns.find(({ name }) => name === field);
     const realPage = page - 1;
 

--- a/src/data-table/utils/sorting.tsx
+++ b/src/data-table/utils/sorting.tsx
@@ -6,12 +6,11 @@ import { ReactNode } from "react";
 export function sortObjects<T extends ReferenceObject>(
     rows: T[],
     columns: TableColumn<T>[],
-    pageSize: number,
     tablePagination: TablePagination,
     tableSorting: TableSorting<T>
 ) {
     const { field, order } = tableSorting;
-    const { page } = tablePagination;
+    const { page, pageSize } = tablePagination;
     const column = columns.find(({ name }) => name === field);
     const realPage = page - 1;
 


### PR DESCRIPTION
Introducing the prop change we spoke in the last weekly meeting @tokland, will be used for ``metadata-sync`` new widget.