### PR TITLE
[Sharing] Add name as a valid title

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-07-01T08:06:53.907Z\n"
-"PO-Revision-Date: 2020-07-01T08:06:53.907Z\n"
+"POT-Creation-Date: 2020-07-29T07:27:35.411Z\n"
+"PO-Revision-Date: 2020-07-29T07:27:35.411Z\n"
 
 msgid "Cancel"
 msgstr ""
@@ -160,10 +160,10 @@ msgstr ""
 msgid "Can capture and view"
 msgstr ""
 
-msgid "Created by"
+msgid "Who has access"
 msgstr ""
 
-msgid "Who has access"
+msgid "Created by"
 msgstr ""
 
 msgid "Add users and user groups"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2020-07-01T08:06:53.907Z\n"
+"POT-Creation-Date: 2020-07-29T07:27:35.411Z\n"
 "PO-Revision-Date: 2019-02-14T11:21:26.165Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -163,10 +163,10 @@ msgstr ""
 msgid "Can capture and view"
 msgstr ""
 
-msgid "Created by"
+msgid "Who has access"
 msgstr ""
 
-msgid "Who has access"
+msgid "Created by"
 msgstr ""
 
 msgid "Add users and user groups"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -134,46 +134,46 @@ msgid "Remove"
 msgstr "Quitar"
 
 msgid "This access cannot be removed"
-msgstr ""
+msgstr "No se puede eleminar este acceso"
 
 msgid "External access"
-msgstr ""
+msgstr "Acceso externo"
 
 msgid "Anyone can view without login"
-msgstr ""
+msgstr "Cualquiera puede ver sin login"
 
 msgid "No access"
-msgstr ""
+msgstr "Sin acceso"
 
 msgid "Public access"
-msgstr ""
+msgstr "Acceso público"
 
 msgid "METADATA"
-msgstr ""
+msgstr "METADATOS"
 
 msgid "Can edit and view"
-msgstr ""
+msgstr "Puede editar y ver"
 
 msgid "Can view only"
-msgstr ""
+msgstr "Puede ver"
 
 msgid "DATA"
-msgstr ""
+msgstr "DATOS"
 
 msgid "Can capture and view"
-msgstr ""
+msgstr "Puede capturar y ver"
 
 msgid "Who has access"
-msgstr ""
+msgstr "¿Quién tiene acceso?"
 
 msgid "Created by"
-msgstr ""
+msgstr "Creado por"
 
 msgid "Add users and user groups"
-msgstr ""
+msgstr "Añadir usuarios y grupos de usuario"
 
 msgid "Enter names"
-msgstr ""
+msgstr "Introduzca nombres"
 
 msgid "Help"
 msgstr "Ayuda"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2020-07-01T08:06:53.907Z\n"
+"POT-Creation-Date: 2020-07-29T07:27:35.411Z\n"
 "PO-Revision-Date: 2019-02-14T11:21:26.165Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -163,10 +163,10 @@ msgstr ""
 msgid "Can capture and view"
 msgstr ""
 
-msgid "Created by"
+msgid "Who has access"
 msgstr ""
 
-msgid "Who has access"
+msgid "Created by"
 msgstr ""
 
 msgid "Add users and user groups"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.6.1-beta.2",
+    "version": "1.6.1-beta.5",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.5.1-beta.5",
+    "version": "1.6.1-beta.1",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.5.1-beta.3",
+    "version": "1.5.1-beta.5",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.6.1-beta.1",
+    "version": "1.6.1-beta.2",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.5.1-beta.2",
+    "version": "1.5.1-beta.3",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/sharing/Table.tsx
+++ b/src/sharing/Table.tsx
@@ -114,6 +114,7 @@ class Table extends React.Component<TablePropsWithStyles> {
         const {
             user,
             displayName,
+            name,
             userAccesses,
             userGroupAccesses,
             publicAccess,
@@ -134,7 +135,7 @@ class Table extends React.Component<TablePropsWithStyles> {
 
         return (
             <div>
-                {showTitle && <h2 className={classes.title}>{displayName}</h2>}
+                {showTitle && <h2 className={classes.title}>{displayName || name}</h2>}
                 {user && (
                     <div className={classes.createdBy}>
                         {`${i18n.t("Created by")}: ${user.name}`}

--- a/src/sharing/Table.tsx
+++ b/src/sharing/Table.tsx
@@ -113,6 +113,7 @@ class Table extends React.Component<TablePropsWithStyles> {
         const { allowPublicAccess, allowExternalAccess } = this.props.meta.meta;
         const { classes, subtitle = i18n.t("Who has access") } = this.props;
         const {
+            id,
             user,
             displayName,
             name,
@@ -136,7 +137,7 @@ class Table extends React.Component<TablePropsWithStyles> {
 
         return (
             <div>
-                {showTitle && <h2 className={classes.title}>{displayName || name}</h2>}
+                {showTitle && <h2 className={classes.title}>{displayName || name || id}</h2>}
                 {user && (
                     <div className={classes.createdBy}>
                         {`${i18n.t("Created by")}: ${user.name}`}

--- a/src/sharing/Table.tsx
+++ b/src/sharing/Table.tsx
@@ -110,7 +110,9 @@ class Table extends React.Component<TablePropsWithStyles> {
     };
 
     render() {
-        const { allowPublicAccess, allowExternalAccess } = this.props.meta.meta;
+        const { allowPublicAccess = true, allowExternalAccess = false } =
+            this.props.meta.meta || {};
+
         const { classes, subtitle = i18n.t("Who has access") } = this.props;
         const {
             id,

--- a/src/sharing/Table.tsx
+++ b/src/sharing/Table.tsx
@@ -21,6 +21,7 @@ export interface TableProps {
         externalSharing: boolean;
         permissionPicker: boolean;
     }>;
+    subtitle?: string;
     unremovebleIds?: Set<Id>;
     // Return a fulfilled promise to signal that the update was successful
     onChange: (sharedUpdate: ShareUpdate) => Promise<void>;
@@ -110,7 +111,7 @@ class Table extends React.Component<TablePropsWithStyles> {
 
     render() {
         const { allowPublicAccess, allowExternalAccess } = this.props.meta.meta;
-        const { classes } = this.props;
+        const { classes, subtitle = i18n.t("Who has access") } = this.props;
         const {
             user,
             displayName,
@@ -142,12 +143,11 @@ class Table extends React.Component<TablePropsWithStyles> {
                     </div>
                 )}
                 <div className={classes.titleBodySpace} />
-                <Typography variant="subtitle1">{i18n.t("Who has access")}</Typography>
+                <Typography variant="subtitle1">{subtitle}</Typography>
                 <Divider />
                 <div className={classes.rules} ref={this.setAccessListRef}>
                     {showPublicSharing && (
                         <React.Fragment>
-                            {" "}
                             <PublicAccess
                                 access={publicAccess}
                                 disabled={!allowPublicAccess}

--- a/src/sharing/types.ts
+++ b/src/sharing/types.ts
@@ -12,7 +12,8 @@ export interface SharingRule {
 export interface SharedObject {
     id: Id;
     user?: { id: Id; name: string };
-    displayName: string;
+    displayName?: string;
+    name: string;
     userAccesses?: SharingRule[];
     userGroupAccesses?: SharingRule[];
     externalAccess: boolean;

--- a/src/sharing/types.ts
+++ b/src/sharing/types.ts
@@ -25,7 +25,7 @@ export type ShareUpdate = Partial<
 >;
 
 export interface MetaObject {
-    meta: {
+    meta?: {
         allowPublicAccess?: boolean;
         allowExternalAccess?: boolean;
     };

--- a/src/sharing/types.ts
+++ b/src/sharing/types.ts
@@ -11,7 +11,7 @@ export interface SharingRule {
 
 export interface SharedObject {
     id: Id;
-    name: string;
+    name?: string;
     displayName?: string;
     user?: { id: Id; name: string };
     userAccesses?: SharingRule[];

--- a/src/sharing/types.ts
+++ b/src/sharing/types.ts
@@ -11,13 +11,13 @@ export interface SharingRule {
 
 export interface SharedObject {
     id: Id;
-    user?: { id: Id; name: string };
-    displayName?: string;
     name: string;
+    displayName?: string;
+    user?: { id: Id; name: string };
     userAccesses?: SharingRule[];
     userGroupAccesses?: SharingRule[];
-    externalAccess: boolean;
-    publicAccess: AccessRule;
+    externalAccess?: boolean;
+    publicAccess?: AccessRule;
 }
 
 export type ShareUpdate = Partial<

--- a/src/sharing/types.ts
+++ b/src/sharing/types.ts
@@ -26,8 +26,8 @@ export type ShareUpdate = Partial<
 
 export interface MetaObject {
     meta: {
-        allowPublicAccess: boolean;
-        allowExternalAccess: boolean;
+        allowPublicAccess?: boolean;
+        allowExternalAccess?: boolean;
     };
     object: SharedObject;
 }


### PR DESCRIPTION
- In all the code we're always checking for ``displayName`` although that's true for most DHIS2 objects, in ``metadata-sync`` we send custom objects such as ``SyncRule`` that use simplified ``name`` instead of ``displayName/shortName/name``

- Also make some props that are optional, as optional types (public/external access)

- Allow customizing subtitle by props, Sharing component is also being used as CC notification list and "Who has access" makes no sense in that scenario