### PR TITLE
Feature/allow no primary action

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "1.5.0",
+    "version": "1.5.1-beta.6",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "@material-ui/pickers": "3.2.10",
         "classnames": "^2.2.6",
         "downshift": "^5.4.2",
-        "lodash": "4.17.15",
+        "lodash": "4.17.19",
         "moment": "^2.22.2",
         "nano-memoize": "1.1.10",
         "node-sass": "^4.12.0",

--- a/src/data-table/DataTableBody.tsx
+++ b/src/data-table/DataTableBody.tsx
@@ -123,6 +123,7 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
 
         const handleClick = (event: MouseEvent<unknown>) => {
             const { tagName, type = null } = event.target as HTMLAnchorElement;
+            if (!tagName) return;
             const isCheckboxClick = tagName.localeCompare("input") && type === "checkbox";
             const activeSelection = _.reject(selected, { indeterminate: true });
 

--- a/src/data-table/DataTableBody.tsx
+++ b/src/data-table/DataTableBody.tsx
@@ -93,7 +93,7 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
 
     function createRow(row: T, index: number | string, level = 0) {
         const labelId = `data-table-row-${index}`;
-        const defaultAction = parseActions([row], availableActions)[0];
+        const showRowActions = parseActions([row], availableActions).length > 0;
         const primaryAction = _(availableActions).find({ primary: true });
 
         const contextualAction = (event: MouseEvent<unknown>) => {

--- a/src/data-table/DataTableBody.tsx
+++ b/src/data-table/DataTableBody.tsx
@@ -94,7 +94,7 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
     function createRow(row: T, index: number | string, level = 0) {
         const labelId = `data-table-row-${index}`;
         const defaultAction = parseActions([row], availableActions)[0];
-        const primaryAction = _(availableActions).find({ primary: true }) || defaultAction;
+        const primaryAction = _(availableActions).find({ primary: true });
 
         const contextualAction = (event: MouseEvent<unknown>) => {
             if (isEventCtrlClick(event)) return;

--- a/src/data-table/DataTableBody.tsx
+++ b/src/data-table/DataTableBody.tsx
@@ -212,7 +212,7 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
                         ))}
 
                     <TableCell key={`${labelId}-actions`} padding="none" align={"center"}>
-                        {!!defaultAction && (
+                        {!!showRowActions && (
                             <Tooltip title={i18n.t("Actions")}>
                                 <IconButton onClick={event => contextualAction(event)}>
                                     <MoreVertIcon />

--- a/yarn.lock
+++ b/yarn.lock
@@ -4853,7 +4853,12 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
-lodash@4.17.15, lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@~4.17.12:
+lodash@4.17.19:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
+lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@~4.17.12:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/project-monitoring-app/pull/261

- Sometimes we don't want a default action to execute as the primary action, this PRs removes the OR fallback.
- Also: when rendering custom components in the table, `handleClick` was getting events with targets that have no tagName, which resulted in an error. Add a check before using it.