### PR TITLE
[ObjectsTable] Add property cellStyle to RowConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.0.0",
+    "version": "2.0.1-beta.3",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/data-table/DataTableBody.tsx
+++ b/src/data-table/DataTableBody.tsx
@@ -153,7 +153,7 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
             });
         };
 
-        const { style, disabled, selectable = !disabled } = rowConfig(row);
+        const { style, cellStyle, disabled, selectable = !disabled } = rowConfig(row);
         const selectedItem: Partial<TableSelection> = _.find(selected, { id: row.id });
         const { checked = !!selectedItem, indeterminate = false, icon = <CheckBoxTwoToneIcon /> } =
             selectedItem || {};
@@ -174,7 +174,11 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
                     hover
                 >
                     {(enableMultipleAction || childrenRows.length > 0) && (
-                        <TableCell padding="checkbox" className={classes.checkboxCell}>
+                        <TableCell
+                            padding="checkbox"
+                            className={classes.checkboxCell}
+                            style={cellStyle}
+                        >
                             <div className={classes.flex}>
                                 {enableMultipleAction && (
                                     <Checkbox
@@ -206,12 +210,18 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
                                 key={`${labelId}-column-${column.name}`}
                                 scope="row"
                                 align="left"
+                                style={cellStyle}
                             >
                                 {formatRowValue(column, row)}
                             </TableCell>
                         ))}
 
-                    <TableCell key={`${labelId}-actions`} padding="none" align={"center"}>
+                    <TableCell
+                        key={`${labelId}-actions`}
+                        padding="none"
+                        align={"center"}
+                        style={cellStyle}
+                    >
                         {!!showRowActions && (
                             <Tooltip title={i18n.t("Actions")}>
                                 <IconButton onClick={event => contextualAction(event)}>

--- a/src/data-table/types.ts
+++ b/src/data-table/types.ts
@@ -27,6 +27,7 @@ export interface TableAction<T extends ReferenceObject> {
 
 export interface RowConfig {
     style?: CSSProperties;
+    cellStyle?: CSSProperties;
     disabled?: boolean;
     selectable?: boolean;
 }


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/metadata-synchronization/pull/606

- `rowConfig.style` (used in `TableRow`) is not enough to override some properties on the cell, so add `rowConfig.cellStyle` and use it in `TableCell` components.