### PR TITLE
[DataTable] Fix select all

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.0.0",
+    "version": "2.0.1-beta.4",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.0.1-beta.4",
+    "version": "2.0.1-beta.5",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.0.0-beta.2",
+    "version": "2.0.1-beta.2",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.0.0",
+    "version": "2.0.0-beta.2",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -192,7 +192,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
     };
 
     const handleSelectAllClick = (event: React.ChangeEvent<HTMLInputElement>) => {
-        const ids = rowObjects
+        const refs = rowObjects
             .filter(row => {
                 const { selectable = true } = rowConfig(row);
                 return selectable;
@@ -201,8 +201,8 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
 
         handleSelectionChange(
             event.target.checked
-                ? _.uniq(selection.concat(ids))
-                : _.differenceBy(selection, ids, "id")
+                ? _.unionBy(selection, refs, "id")
+                : _.differenceBy(selection, refs, "id")
         );
     };
 

--- a/src/data-table/utils/formatting.tsx
+++ b/src/data-table/utils/formatting.tsx
@@ -20,7 +20,7 @@ function defaultFormatter(value: any): ReactNode {
         );
     } else if (value.displayName || value.name || value.id) {
         return value.displayName || value.name || value.id;
-    } else if (moment.isDate(value) || moment.isMoment(value) || isStringDate(value)) {
+    } else if (isValidDate(value)) {
         return moment(value).format("YYYY-MM-DD HH:mm:ss");
     } else {
         return <Linkify key={value}>{value}</Linkify>;
@@ -37,11 +37,12 @@ export function formatRowValue<T extends ReferenceObject>(
 
 export const defaultRowConfig = () => ({} as RowConfig);
 
-function isStringDate(value: any): boolean {
-    // Avoid dubious positives by skipping strings that do not contain at least year, month and day.
-    if (typeof value === "string" && value.length >= "YYYY-MM-DD".length) {
-        return moment(value, moment.ISO_8601, true).isValid();
-    } else {
-        return false;
-    }
+// Avoid dubious positives by skipping strings that do not contain at least year, month and day.
+function isValidDate(value: any): boolean {
+    if (moment.isDate(value) || moment.isMoment(value)) return true;
+
+    const date = moment(value, moment.ISO_8601, true);
+    const { format } = date.creationData();
+
+    return format !== "YYYY" && format !== "YYYY-MM" && date.isValid();
 }

--- a/src/data-table/utils/formatting.tsx
+++ b/src/data-table/utils/formatting.tsx
@@ -20,11 +20,7 @@ function defaultFormatter(value: any): ReactNode {
         );
     } else if (value.displayName || value.name || value.id) {
         return value.displayName || value.name || value.id;
-    } else if (
-        moment.isDate(value) ||
-        moment.isMoment(value) ||
-        moment(value, moment.ISO_8601, true).isValid()
-    ) {
+    } else if (moment.isDate(value) || moment.isMoment(value) || isStringDate(value)) {
         return moment(value).format("YYYY-MM-DD HH:mm:ss");
     } else {
         return <Linkify key={value}>{value}</Linkify>;
@@ -40,3 +36,12 @@ export function formatRowValue<T extends ReferenceObject>(
 }
 
 export const defaultRowConfig = () => ({} as RowConfig);
+
+function isStringDate(value: any): boolean {
+    // Avoid dubious positives by skipping strings that do not contain at least year, month and day.
+    if (typeof value === "string" && value.length >= "YYYY-MM-DD".length) {
+        return moment(value, moment.ISO_8601, true).isValid();
+    } else {
+        return false;
+    }
+}


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/metadata-synchronization/issues/594

- Since objects are references (`{id: ID}`), `_.uniq(selection.concat(ids))` should be `_.uniqBy(selection.concat(ids), "id")`. Finally, I've used `_.unionBy`, which is equivalent to concat+uniqBy.
- Changed `ids`->`refs` to make more clear its content (if they had been really ids, uniq would have been correct).