### PR TITLE
Fix/org units selector search

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.1.0-beta.7",
+    "version": "2.1.0",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.0.1",
+    "version": "2.1.0-beta.7",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/data-table/utils/formatting.tsx
+++ b/src/data-table/utils/formatting.tsx
@@ -37,12 +37,13 @@ export function formatRowValue<T extends ReferenceObject>(
 
 export const defaultRowConfig = () => ({} as RowConfig);
 
-// Avoid dubious positives by skipping strings that do not contain at least year, month and day.
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 function isValidDate(value: any): boolean {
     if (moment.isDate(value) || moment.isMoment(value)) return true;
 
     const date = moment(value, moment.ISO_8601, true);
     const { format } = date.creationData();
 
+    // Avoid dubious positives by skipping strings that do not contain at least year, month and day
     return format !== "YYYY" && format !== "YYYY-MM" && date.isValid();
 }

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -149,11 +149,10 @@ export default class OrgUnitsSelector extends React.Component {
         const postFilter = search
             ? orgUnits =>
                   _(orgUnits)
-                      .filter(
-                          orgUnit =>
-                              (!selectableLevels &&
-                                  rootIds.some(ouId => orgUnit.path.includes(ouId))) ||
-                              selectableLevels.includes(orgUnit.level)
+                      .filter(orgUnit =>
+                          selectableLevels
+                              ? selectableLevels.includes(orgUnit.level)
+                              : !rootIds || rootIds.some(ouId => orgUnit.path.includes(ouId))
                       )
                       .take(10)
                       .value()

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -154,7 +154,7 @@ export default class OrgUnitsSelector extends React.Component {
                               ? selectableLevels.includes(orgUnit.level)
                               : !rootIds || rootIds.some(ouId => orgUnit.path.includes(ouId))
                       )
-                      .take(10)
+                      .take(50)
                       .value()
             : _.identity;
 


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/metadata-synchronization/issues/637

- `rootIds` is an optional prop, check presence before using it.

