### PR TITLE
Change title in ConfirmationDialog to string or ReacNode

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.2.0-beta.1",
+    "version": "2.2.0-beta.2",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/confirmation-dialog/ConfirmationDialog.tsx
+++ b/src/confirmation-dialog/ConfirmationDialog.tsx
@@ -11,9 +11,9 @@ import _ from "lodash";
 import React, { ReactNode } from "react";
 import i18n from "../utils/i18n";
 
-export interface ConfirmationDialogProps extends Partial<DialogProps> {
+export interface ConfirmationDialogProps extends Partial<Omit<DialogProps, "title">> {
     isOpen?: boolean;
-    title?: string;
+    title?: string | ReactNode;
     description?: string | ReactNode;
     onSave?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
     onCancel?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/metadata-synchronization/pull/670

Enable pass title as ReacNode