### PR TITLE
[ObjectsTable] Add standard className prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.2.0",
+    "version": "2.2.0-beta.3",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {
@@ -27,6 +27,7 @@
         "@dhis2/d2-i18n-extract": "^1.0.7",
         "@dhis2/d2-i18n-generate": "^1.0.18",
         "@material-ui/core": "4.9.4",
+        "@types/classnames": "^2.2.11",
         "@types/enzyme": "^3.1.17",
         "@types/jest": "^24.0.3",
         "@types/lodash": "^4.14.144",

--- a/src/data-table/ObjectsTable.tsx
+++ b/src/data-table/ObjectsTable.tsx
@@ -1,5 +1,6 @@
 import React, { useState, ReactNode, MouseEvent, useCallback, useMemo } from "react";
 import _ from "lodash";
+import classnames from "classnames";
 import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
 import DetailsIcon from "@material-ui/icons/Details";
 import { SearchBox } from "..";
@@ -35,6 +36,7 @@ export interface ObjectsTableProps<T extends ReferenceObject> extends DataTableP
     searchBoxColumns?: (keyof T)[];
     onActionButtonClick?(event: MouseEvent<unknown>): void;
     actionButtonLabel?: ReactNode;
+    className?: string;
 }
 
 export function ObjectsTable<T extends ReferenceObject = TableObject>(props: ObjectsTableProps<T>) {
@@ -52,6 +54,7 @@ export function ObjectsTable<T extends ReferenceObject = TableObject>(props: Obj
         sideComponents: parentSideComponents,
         resetKey = "",
         childrenKeys = [],
+        className,
         ...rest
     } = props;
     const classes = useStyles();
@@ -96,13 +99,13 @@ export function ObjectsTable<T extends ReferenceObject = TableObject>(props: Obj
         () => (
             <React.Fragment>
                 {showSearchBox && (
-                    <div key={"objects-table-search-box"} className={classes.searchBox}>
-                        <SearchBox
-                            value={searchValue}
-                            hintText={searchBoxLabel || "Search items"}
-                            onChange={handleSearchChange}
-                        />
-                    </div>
+                    <SearchBox
+                        key={"objects-table-search-box"}
+                        className={classes.searchBox}
+                        value={searchValue}
+                        hintText={searchBoxLabel || "Search items"}
+                        onChange={handleSearchChange}
+                    />
                 )}
                 {parentFilterComponents}
             </React.Fragment>
@@ -140,7 +143,7 @@ export function ObjectsTable<T extends ReferenceObject = TableObject>(props: Obj
             : parentRows;
 
     return (
-        <div className={classes.root}>
+        <div className={classnames([classes.root, className])}>
             <DataTable
                 rows={rows}
                 actions={actions}

--- a/src/search-box/SearchBox.tsx
+++ b/src/search-box/SearchBox.tsx
@@ -2,11 +2,13 @@ import TextField from "@material-ui/core/TextField";
 import _ from "lodash";
 import React, { useCallback, useState, useEffect } from "react";
 import i18n from "../utils/i18n";
+
 export interface SearchBoxProps {
     value?: string;
     debounce?: number;
     onChange(value: string): void;
     hintText?: string;
+    className?: string;
 }
 
 const styles = {
@@ -18,6 +20,7 @@ export const SearchBox: React.FC<SearchBoxProps> = ({
     hintText = i18n.t("Search by name"),
     onChange,
     debounce: debounceTime = 400,
+    className,
 }) => {
     const [stateValue, updateStateValue] = useState(value);
     useEffect(() => updateStateValue(value), [value]);
@@ -47,6 +50,7 @@ export const SearchBox: React.FC<SearchBoxProps> = ({
             onChange={onKeyUp}
             placeholder={hintText}
             data-test="search"
+            className={className}
         />
     );
 };


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/project-monitoring-app/issues/333

For styled-components to work, exported root components must accept the standard `className` prop. 

Note that generic components like `ObjectsTable<T>` need casting. Something like this:

```typescript
const ObjectsTableStyled = styled(ObjectsTable)`
    .MuiTextField-root {
        max-width: 400px;
    }
` as typeof ObjectsTable;
```

Caveat: `ObjectsTableStyled` has no longer type `StyledComponent`, so it's not ideal. How to do it properly? I've not found a satisfactory solution (the wrapper option proposed in some issues is not usable, as it creates a dynamic component on every render).