### PR TITLE
Fix bug with progress bar hidden by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.3.0",
+    "version": "2.4.0-beta.2",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/loading/LoadingConsumer.tsx
+++ b/src/loading/LoadingConsumer.tsx
@@ -38,7 +38,7 @@ const LoadingConsumer = () => {
         <LoadingContext.Consumer>
             {state => {
                 if (!state) throw new Error("Loading context has not been defined");
-                const { isLoading, message, progress = 0 } = state;
+                const { isLoading, message, progress = -1 } = state;
 
                 const hideMessage = !message || !message.trim();
                 return (


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/metadata-synchronization/pull/759

- [x] Fix bug when the indeterminate progress bar is hidden by default.