### PR TITLE
[Feature] Add dropdown components

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-12-15T09:17:37.924Z\n"
-"PO-Revision-Date: 2020-12-15T09:17:37.924Z\n"
+"POT-Creation-Date: 2021-01-05T11:11:10.606Z\n"
+"PO-Revision-Date: 2021-01-05T11:11:10.606Z\n"
 
 msgid "Cancel"
 msgstr ""
@@ -53,6 +53,9 @@ msgid "All {{total}} items on this page are selected."
 msgstr ""
 
 msgid "Select all {{total}} items in all pages"
+msgstr ""
+
+msgid "<No value>"
 msgstr ""
 
 msgid "Hidden by filters"
@@ -107,9 +110,6 @@ msgid "Organisation unit level"
 msgstr ""
 
 msgid "Program"
-msgstr ""
-
-msgid "<No value>"
 msgstr ""
 
 msgid "Select"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2020-12-15T09:17:37.924Z\n"
+"POT-Creation-Date: 2021-01-05T11:11:10.606Z\n"
 "PO-Revision-Date: 2019-02-14T11:21:26.165Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,6 +58,9 @@ msgstr "Todos los {{total}} elementos en esta página están seleccionados"
 msgid "Select all {{total}} items in all pages"
 msgstr "Seleccione todos los {{total}} elementos en todas las páginas"
 
+msgid "<No value>"
+msgstr "<Sin valor>"
+
 msgid "Hidden by filters"
 msgstr "Ocultos por filtro"
 
@@ -111,9 +114,6 @@ msgstr "Nivel de unidad organizativa"
 
 msgid "Program"
 msgstr ""
-
-msgid "<No value>"
-msgstr "<Sin valor>"
 
 msgid "Select"
 msgstr "Seleccionar"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2020-12-15T09:17:37.924Z\n"
+"POT-Creation-Date: 2021-01-05T11:11:10.606Z\n"
 "PO-Revision-Date: 2019-02-14T11:21:26.165Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,6 +58,9 @@ msgstr "Tous les {{total}} éléments de cette page sont sélectionnés"
 msgid "Select all {{total}} items in all pages"
 msgstr "Sélectionnez tous les {{{total}}} éléments dans toutes les pages"
 
+msgid "<No value>"
+msgstr ""
+
 msgid "Hidden by filters"
 msgstr "Caché par des filtres"
 
@@ -110,9 +113,6 @@ msgid "Organisation unit level"
 msgstr "Niveau de l'Unité d'Organisation"
 
 msgid "Program"
-msgstr ""
-
-msgid "<No value>"
 msgstr ""
 
 msgid "Select"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "d2-ui-components",
+    "name": "@eyeseetea/d2-ui-components",
     "description": "Components for DHIS2 apps",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.5.0-beta.1",
+    "version": "2.5.0",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.4.0-beta.4",
+    "version": "2.5.0-beta.1",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/dropdown/Dropdown.tsx
+++ b/src/dropdown/Dropdown.tsx
@@ -1,0 +1,57 @@
+import { MenuItem, Select } from "@material-ui/core";
+import React from "react";
+import i18n from "../utils/i18n";
+import { DropdownForm, DropdownItem } from "./GenericDropdown";
+
+export interface DropdownProps<Value extends string = string> {
+    className?: string;
+    items: DropdownItem[];
+    onChange: (value: Value | undefined) => void;
+    label?: string;
+    value?: Value;
+    hideEmpty?: boolean;
+}
+
+interface SelectProps {
+    className?: string;
+    label?: string;
+}
+
+const SelectWrapper: React.FC<SelectProps> = React.memo(props => {
+    const { className, label, children } = props;
+    return label ? (
+        <DropdownForm className={className} label={label}>
+            {children}
+        </DropdownForm>
+    ) : (
+        <div className={className}>{children}</div>
+    );
+});
+
+export const Dropdown: React.FC<DropdownProps> = React.memo(props => {
+    const { items, value, onChange, label, hideEmpty, className } = props;
+
+    const selectValue =
+        value === undefined || !items.map(item => item.value).includes(value) ? "" : value;
+
+    return (
+        <SelectWrapper className={className} label={label}>
+            <Select
+                data-cy={label}
+                value={selectValue}
+                onChange={ev => onChange((ev.target.value as string) || undefined)}
+                MenuProps={{
+                    getContentAnchorEl: null,
+                    anchorOrigin: { vertical: "bottom", horizontal: "left" },
+                }}
+            >
+                {!hideEmpty && <MenuItem value={""}>{i18n.t("<No value>")}</MenuItem>}
+                {items.map(item => (
+                    <MenuItem key={item.value} value={item.value}>
+                        {item.text}
+                    </MenuItem>
+                ))}
+            </Select>
+        </SelectWrapper>
+    );
+});

--- a/src/dropdown/GenericDropdown.tsx
+++ b/src/dropdown/GenericDropdown.tsx
@@ -1,0 +1,66 @@
+import { createMuiTheme, FormControl, InputLabel, MuiThemeProvider } from "@material-ui/core";
+import cyan from "@material-ui/core/colors/cyan";
+import React from "react";
+
+export type DropdownItem<Value extends string = string> = { value: Value; text: string };
+
+export interface DropdownFormProps {
+    className?: string;
+    label: string;
+}
+
+export const DropdownForm: React.FC<DropdownFormProps> = React.memo(props => {
+    const { className, label, children } = props;
+    const materialTheme = getMaterialTheme();
+
+    return (
+        <MuiThemeProvider theme={materialTheme}>
+            <FormControl className={className}>
+                <InputLabel>{label}</InputLabel>
+                {children}
+            </FormControl>
+        </MuiThemeProvider>
+    );
+});
+
+const getMaterialTheme = () =>
+    createMuiTheme({
+        overrides: {
+            MuiFormLabel: {
+                root: {
+                    color: "#aaaaaa",
+                    "&$focused": {
+                        color: "#aaaaaa",
+                    },
+                    top: "-9px !important",
+                    marginLeft: 10,
+                },
+            },
+            MuiInput: {
+                root: {
+                    marginLeft: 10,
+                },
+                formControl: {
+                    minWidth: 150,
+                    marginTop: "8px !important",
+                },
+                input: {
+                    color: "#565656",
+                },
+                underline: {
+                    "&&&&:hover:before": {
+                        borderBottom: `1px solid #bdbdbd`,
+                    },
+                    "&:hover:not($disabled):before": {
+                        borderBottom: `1px solid #aaaaaa`,
+                    },
+                    "&:after": {
+                        borderBottom: `2px solid ${cyan["500"]}`,
+                    },
+                    "&:before": {
+                        borderBottom: `1px solid #bdbdbd`,
+                    },
+                },
+            },
+        },
+    });

--- a/src/dropdown/MultipleDropdown.tsx
+++ b/src/dropdown/MultipleDropdown.tsx
@@ -1,0 +1,39 @@
+import { MenuItem, MenuProps, Select } from "@material-ui/core";
+import React from "react";
+import { DropdownForm, DropdownItem } from "./GenericDropdown";
+
+export interface MultipleDropdownProps<Value extends string = string> {
+    className?: string;
+    items: DropdownItem[];
+    onChange: (values: Value[]) => void;
+    label: string;
+    values: Value[];
+}
+
+const menuProps: Partial<MenuProps> = {
+    getContentAnchorEl: null,
+    anchorOrigin: { vertical: "bottom", horizontal: "left" },
+};
+
+export const MultipleDropdown: React.FC<MultipleDropdownProps> = React.memo(props => {
+    const { items, values, onChange, label, className } = props;
+    const notifyChange = React.useCallback(ev => onChange(ev.target.value as string[]), [onChange]);
+
+    return (
+        <DropdownForm className={className} label={label}>
+            <Select
+                multiple={true}
+                data-test-multiple-dropdown={label}
+                value={values}
+                onChange={notifyChange}
+                MenuProps={menuProps}
+            >
+                {items.map(item => (
+                    <MenuItem key={item.value} value={item.value}>
+                        {item.text}
+                    </MenuItem>
+                ))}
+            </Select>
+        </DropdownForm>
+    );
+});

--- a/src/dropdown/index.ts
+++ b/src/dropdown/index.ts
@@ -1,0 +1,3 @@
+export { DropdownItem } from "./GenericDropdown";
+export { Dropdown, DropdownProps } from "./Dropdown";
+export { MultipleDropdown, MultipleDropdownProps } from "./MultipleDropdown";

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export * from "./data-table/DataTable";
 export * from "./data-table/ObjectsTable";
 export * from "./data-table/types";
 export * from "./date-picker/DatePicker";
+export * from "./dropdown";
 export * from "./loading";
 export * from "./search-box/SearchBox";
 export * from "./snackbar";


### PR DESCRIPTION
We are using Dropdowns in almost every app with different implementations. We are adding it once again form ``predictors-extended`` so I'm bringing the code from ``project-monitoring`` with small changes introduced in ``metadata-sync``.

  - Added type narrowing for unions
  - Added className overrides for styled-components
  - Migrated to NamedExports instead of DefaultExports﻿
