### PR TITLE
[snackbar] keep open on page clickaway

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.6.6",
+    "version": "2.6.7-beta.1",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/snackbar/SnackbarConsumer.tsx
+++ b/src/snackbar/SnackbarConsumer.tsx
@@ -73,6 +73,10 @@ const SnackbarConsumer = () => {
                 if (!state) throw new Error("Snackbar context has not been defined");
                 const { isOpen, message, variant, closeSnackbar, autoHideDuration } = state;
 
+                function notifyClose(_ev: React.SyntheticEvent<any>, reason: string) {
+                    if (reason !== "clickaway") closeSnackbar();
+                }
+
                 if (!variant || !variantIcon[variant]) {
                     throw new Error(`Unknown variant: ${variant}`);
                 }
@@ -85,7 +89,7 @@ const SnackbarConsumer = () => {
                         anchorOrigin={anchorOrigin}
                         open={isOpen}
                         autoHideDuration={autoHideDuration}
-                        onClose={closeSnackbar}
+                        onClose={notifyClose}
                     >
                         <SnackbarContent
                             className={classes[variant]}


### PR DESCRIPTION
Problem: when clicking on the page, the snack bar would close.

Solution: https://github.com/mui-org/material-ui/issues/5184#issuecomment-569418493