### PR TITLE
ColumnSelectorDialog: allow column ordering

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-04-09T08:17:10.988Z\n"
-"PO-Revision-Date: 2021-04-09T08:17:10.988Z\n"
+"POT-Creation-Date: 2021-11-24T07:20:30.326Z\n"
+"PO-Revision-Date: 2021-11-24T07:20:30.326Z\n"
 
 msgid "Cancel"
 msgstr ""
@@ -23,9 +23,6 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-msgid "Column"
-msgstr ""
-
 msgid "Actions"
 msgstr ""
 
@@ -36,6 +33,9 @@ msgid "Loading details..."
 msgstr ""
 
 msgid "No detail fields provided"
+msgstr ""
+
+msgid "Column"
 msgstr ""
 
 msgid "Clear selection"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2021-04-09T08:17:10.988Z\n"
+"POT-Creation-Date: 2021-11-24T07:20:30.326Z\n"
 "PO-Revision-Date: 2019-02-14T11:21:26.165Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,9 +23,6 @@ msgstr "Columnas a mostrar en la tabla"
 msgid "Close"
 msgstr "Cerrar"
 
-msgid "Column"
-msgstr "Columna"
-
 msgid "Actions"
 msgstr "Acciones"
 
@@ -37,6 +34,9 @@ msgstr "Cargando detalles..."
 
 msgid "No detail fields provided"
 msgstr "No se han especificado campos de detalle"
+
+msgid "Column"
+msgstr "Columna"
 
 msgid "Clear selection"
 msgstr "Borrar selección"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2021-04-09T08:17:10.988Z\n"
+"POT-Creation-Date: 2021-11-24T07:20:30.326Z\n"
 "PO-Revision-Date: 2019-02-14T11:21:26.165Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -23,9 +23,6 @@ msgstr ""
 msgid "Close"
 msgstr "Fermer"
 
-msgid "Column"
-msgstr ""
-
 msgid "Actions"
 msgstr "Opérations"
 
@@ -36,6 +33,9 @@ msgid "Loading details..."
 msgstr ""
 
 msgid "No detail fields provided"
+msgstr ""
+
+msgid "Column"
 msgstr ""
 
 msgid "Clear selection"

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
         "@date-io/moment": "1.0.2",
         "@dhis2/d2-i18n": "1.0.6",
         "@dhis2/d2-ui-core": "6.3.0",
+        "@dhis2/ui": "6.15.2",
         "@material-ui/pickers": "3.2.10",
         "classnames": "2.2.6",
         "downshift": "5.4.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.6.9-beta.2",
+    "version": "2.6.9-beta.3",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.6.9-beta.1",
+    "version": "2.6.9-beta.2",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.6.9-beta.3",
+    "version": "2.6.9-beta.4",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.6.8",
+    "version": "2.6.9-beta.1",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/data-table/ColumnSelectorDialog.tsx
+++ b/src/data-table/ColumnSelectorDialog.tsx
@@ -16,8 +16,7 @@ interface ColumnSelectorDialogProps<T extends ReferenceObject> {
 export function ColumnSelectorDialog<T extends ReferenceObject>(
     props: ColumnSelectorDialogProps<T>
 ) {
-    const reorder = typeof props.reorder === "undefined" ? true : props.reorder;
-    const { columns, visibleColumns, onChange, onCancel } = props;
+    const { columns, visibleColumns, onChange, onCancel, reorder = true } = props;
     const transferOptions: TransferOption[] = columns.map(
         ({ name, text: label }): TransferOption => ({ label, value: name.toString() })
     );

--- a/src/data-table/ColumnSelectorDialog.tsx
+++ b/src/data-table/ColumnSelectorDialog.tsx
@@ -9,7 +9,7 @@ interface ColumnSelectorDialogProps<T extends ReferenceObject> {
     columns: TableColumn<T>[];
     visibleColumns: (keyof T)[];
     reorder?: boolean;
-    onChange: (visibleColumns: (keyof T)[] | string[]) => void;
+    onChange: (visibleColumns: (keyof T)[]) => void;
     onCancel: () => void;
 }
 
@@ -37,7 +37,7 @@ export function ColumnSelectorDialog<T extends ReferenceObject>(
                 {reorder && (
                     <Transfer
                         enableOrderChange
-                        onChange={({ selected }) => onChange(selected)}
+                        onChange={({ selected }) => onChange(selected as (keyof T)[])}
                         options={transferOptions}
                         selected={selected}
                     />

--- a/src/data-table/ColumnSelectorDialog.tsx
+++ b/src/data-table/ColumnSelectorDialog.tsx
@@ -1,31 +1,28 @@
-import { Checkbox, DialogContent } from "@material-ui/core";
-import Table from "@material-ui/core/Table";
-import TableBody from "@material-ui/core/TableBody";
-import TableCell from "@material-ui/core/TableCell";
-import TableHead from "@material-ui/core/TableHead";
-import TableRow from "@material-ui/core/TableRow";
+import { DialogContent } from "@material-ui/core";
 import React from "react";
 import { ConfirmationDialog, ReferenceObject, TableColumn } from "..";
+import { TableColumnSelector } from "./TableColumnSelector";
 import i18n from "../utils/i18n";
+import { TransferOption, Transfer } from "@dhis2/ui";
 
 interface ColumnSelectorDialogProps<T extends ReferenceObject> {
     columns: TableColumn<T>[];
     visibleColumns: (keyof T)[];
-    onChange: (visibleColumns: (keyof T)[]) => void;
+    reorder?: boolean;
+    onChange: (visibleColumns: (keyof T)[] | string[]) => void;
     onCancel: () => void;
 }
 
 export function ColumnSelectorDialog<T extends ReferenceObject>(
     props: ColumnSelectorDialogProps<T>
 ) {
+    const reorder = typeof props.reorder === "undefined" ? true : props.reorder;
     const { columns, visibleColumns, onChange, onCancel } = props;
-
-    const toggleElement = (name: keyof T) => {
-        const newSelection = !visibleColumns.includes(name)
-            ? [...visibleColumns, name]
-            : visibleColumns.filter(item => item !== name);
-        onChange(newSelection);
-    };
+    const transferOptions: TransferOption[] = columns.map(
+        ({ name, text: label }): TransferOption => ({ label, value: name.toString() })
+    );
+    const selected = visibleColumns.map(column => column.toString());
+    const tableColumnSelectorProps = { columns, visibleColumns, onChange };
 
     return (
         <ConfirmationDialog
@@ -37,37 +34,16 @@ export function ColumnSelectorDialog<T extends ReferenceObject>(
             disableEnforceFocus
         >
             <DialogContent>
-                <Table>
-                    <TableHead>
-                        <TableRow>
-                            <TableCell colSpan={12}>{i18n.t("Column")}</TableCell>
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        {columns.map(({ name, text }) => {
-                            const checked = visibleColumns.includes(name);
-                            const disabled = visibleColumns.length <= 1 && checked;
+                {reorder && (
+                    <Transfer
+                        enableOrderChange
+                        onChange={({ selected }) => onChange(selected)}
+                        options={transferOptions}
+                        selected={selected}
+                    />
+                )}
 
-                            return (
-                                <TableRow key={`cell-${name}`}>
-                                    <TableCell
-                                        component="th"
-                                        scope="row"
-                                        onClick={() => !disabled && toggleElement(name)}
-                                    >
-                                        <Checkbox
-                                            color={"primary"}
-                                            checked={checked}
-                                            disabled={disabled}
-                                            tabIndex={-1}
-                                        />
-                                        {text}
-                                    </TableCell>
-                                </TableRow>
-                            );
-                        })}
-                    </TableBody>
-                </Table>
+                {!reorder && <TableColumnSelector {...tableColumnSelectorProps} />}
             </DialogContent>
         </ConfirmationDialog>
     );

--- a/src/data-table/ColumnSelectorDialog.tsx
+++ b/src/data-table/ColumnSelectorDialog.tsx
@@ -39,6 +39,7 @@ export function ColumnSelectorDialog<T extends ReferenceObject>(
                         filterablePicked={true}
                         selectedWidth="100%"
                         optionsWidth="100%"
+                        height="400px"
                         onChange={({ selected }: { selected: Array<keyof T> }) =>
                             onChange(selected)
                         }

--- a/src/data-table/ColumnSelectorDialog.tsx
+++ b/src/data-table/ColumnSelectorDialog.tsx
@@ -1,14 +1,14 @@
+import { Transfer } from "@dhis2/ui";
 import { DialogContent } from "@material-ui/core";
 import React from "react";
 import { ConfirmationDialog, ReferenceObject, TableColumn } from "..";
-import { TableColumnSelector } from "./TableColumnSelector";
 import i18n from "../utils/i18n";
-import { TransferOption, Transfer } from "@dhis2/ui";
+import { TableColumnSelector } from "./TableColumnSelector";
 
 interface ColumnSelectorDialogProps<T extends ReferenceObject> {
     columns: TableColumn<T>[];
     visibleColumns: (keyof T)[];
-    reorder?: boolean;
+    allowReorderingColumns?: boolean;
     onChange: (visibleColumns: (keyof T)[]) => void;
     onCancel: () => void;
 }
@@ -16,12 +16,8 @@ interface ColumnSelectorDialogProps<T extends ReferenceObject> {
 export function ColumnSelectorDialog<T extends ReferenceObject>(
     props: ColumnSelectorDialogProps<T>
 ) {
-    const { columns, visibleColumns, onChange, onCancel, reorder = true } = props;
-    const transferOptions: TransferOption[] = columns.map(
-        ({ name, text: label }): TransferOption => ({ label, value: name.toString() })
-    );
-    const selected = visibleColumns.map(column => column.toString());
-    const tableColumnSelectorProps = { columns, visibleColumns, onChange };
+    const { columns, visibleColumns, onChange, onCancel, allowReorderingColumns = true } = props;
+    const sortableColumns = columns.map(({ name, text: label }) => ({ label, value: name }));
 
     return (
         <ConfirmationDialog
@@ -29,20 +25,27 @@ export function ColumnSelectorDialog<T extends ReferenceObject>(
             title={i18n.t("Columns to show in table")}
             onCancel={onCancel}
             cancelText={i18n.t("Close")}
-            fullWidth
+            maxWidth={"lg"}
+            fullWidth={true}
             disableEnforceFocus
         >
             <DialogContent>
-                {reorder && (
+                {allowReorderingColumns ? (
                     <Transfer
-                        enableOrderChange
-                        onChange={({ selected }) => onChange(selected as (keyof T)[])}
-                        options={transferOptions}
-                        selected={selected}
+                        options={sortableColumns}
+                        selected={visibleColumns}
+                        enableOrderChange={true}
+                        onChange={({ selected }: { selected: Array<keyof T> }) =>
+                            onChange(selected)
+                        }
+                    />
+                ) : (
+                    <TableColumnSelector
+                        columns={columns}
+                        visibleColumns={visibleColumns}
+                        onChange={onChange}
                     />
                 )}
-
-                {!reorder && <TableColumnSelector {...tableColumnSelectorProps} />}
             </DialogContent>
         </ConfirmationDialog>
     );

--- a/src/data-table/ColumnSelectorDialog.tsx
+++ b/src/data-table/ColumnSelectorDialog.tsx
@@ -35,6 +35,10 @@ export function ColumnSelectorDialog<T extends ReferenceObject>(
                         options={sortableColumns}
                         selected={visibleColumns}
                         enableOrderChange={true}
+                        filterable={true}
+                        filterablePicked={true}
+                        selectedWidth="100%"
+                        optionsWidth="100%"
                         onChange={({ selected }: { selected: Array<keyof T> }) =>
                             onChange(selected)
                         }

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -84,6 +84,7 @@ export interface DataTableProps<T extends ReferenceObject> {
     globalActions?: TableGlobalAction[];
     initialState?: TableInitialState<T>;
     forceSelectionColumn?: boolean;
+    allowReorderingColumns?: boolean;
     hideSelectionMessages?: boolean;
     hideColumnVisibilityOptions?: boolean;
     hideSelectAll?: boolean;
@@ -130,6 +131,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
         resetKey,
         mouseActionsMapping,
         selectionMessages: overrideSelectionMessages,
+        allowReorderingColumns,
     } = props;
 
     const [stateSelection, updateSelection] = useState(initialState.selection || []);
@@ -277,6 +279,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
                             enableMultipleAction={enableMultipleAction}
                             hideColumnVisibilityOptions={hideColumnVisibilityOptions}
                             hideSelectAll={hideSelectAll}
+                            allowReorderingColumns={allowReorderingColumns}
                         />
                         <DataTableBody
                             rows={rowObjects}

--- a/src/data-table/DataTableBody.tsx
+++ b/src/data-table/DataTableBody.tsx
@@ -23,6 +23,7 @@ import {
 import { formatRowValue } from "./utils/formatting";
 import { isEventCtrlClick, parseActions, updateSelection } from "./utils/selection";
 import i18n from "../utils/i18n";
+import { nullColumn } from "./utils/sorting";
 
 const defaultMouseActionsMapping: MouseActionsMapping = {
     left: { type: "primary" },
@@ -204,8 +205,8 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
                         </TableCell>
                     )}
 
-                    {columns
-                        .filter(({ name }) => visibleColumns.includes(name))
+                    {visibleColumns
+                        .map(vc => columns.find(c => c.name === vc) || nullColumn)
                         .map(column => (
                             <TableCell
                                 key={`${labelId}-column-${column.name}`}
@@ -213,7 +214,7 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
                                 align="left"
                                 style={cellStyle}
                             >
-                                {formatRowValue(column, row)}
+                                {formatRowValue(column as TableColumn<T>, row)}
                             </TableCell>
                         ))}
 

--- a/src/data-table/DataTableBody.tsx
+++ b/src/data-table/DataTableBody.tsx
@@ -10,6 +10,7 @@ import ChevronRightIcon from "@material-ui/icons/ChevronRight";
 import MoreVertIcon from "@material-ui/icons/MoreVert";
 import _ from "lodash";
 import React, { MouseEvent, useState } from "react";
+import i18n from "../utils/i18n";
 import {
     MouseActionMapping,
     MouseActionsMapping,
@@ -22,8 +23,6 @@ import {
 } from "./types";
 import { formatRowValue } from "./utils/formatting";
 import { isEventCtrlClick, parseActions, updateSelection } from "./utils/selection";
-import i18n from "../utils/i18n";
-import { nullColumn } from "./utils/sorting";
 
 const defaultMouseActionsMapping: MouseActionsMapping = {
     left: { type: "primary" },
@@ -205,8 +204,9 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
                         </TableCell>
                     )}
 
-                    {visibleColumns
-                        .map(vc => columns.find(c => c.name === vc) || nullColumn)
+                    {_(visibleColumns)
+                        .map(vc => columns.find(c => c.name === vc))
+                        .compact()
                         .map(column => (
                             <TableCell
                                 key={`${labelId}-column-${column.name}`}
@@ -214,9 +214,10 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
                                 align="left"
                                 style={cellStyle}
                             >
-                                {formatRowValue(column as TableColumn<T>, row)}
+                                {formatRowValue(column, row)}
                             </TableCell>
-                        ))}
+                        ))
+                        .value()}
 
                     <TableCell
                         key={`${labelId}-actions`}

--- a/src/data-table/DataTableBody.tsx
+++ b/src/data-table/DataTableBody.tsx
@@ -163,6 +163,10 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
             disabled ? classes.disabledRow : null,
         ]).join(" ");
 
+        const currentColumns = _.compact(
+            visibleColumns.map(column => columns.find(({ name }) => name === column))
+        );
+
         return (
             <React.Fragment key={`data-table-row-${index}`}>
                 <TableRow
@@ -204,20 +208,16 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
                         </TableCell>
                     )}
 
-                    {_(visibleColumns)
-                        .map(vc => columns.find(c => c.name === vc))
-                        .compact()
-                        .map(column => (
-                            <TableCell
-                                key={`${labelId}-column-${column.name}`}
-                                scope="row"
-                                align="left"
-                                style={cellStyle}
-                            >
-                                {formatRowValue(column, row)}
-                            </TableCell>
-                        ))
-                        .value()}
+                    {currentColumns.map(column => (
+                        <TableCell
+                            key={`${labelId}-column-${column.name}`}
+                            scope="row"
+                            align="left"
+                            style={cellStyle}
+                        >
+                            {formatRowValue(column, row)}
+                        </TableCell>
+                    ))}
 
                     <TableCell
                         key={`${labelId}-actions`}

--- a/src/data-table/DataTableHeader.tsx
+++ b/src/data-table/DataTableHeader.tsx
@@ -22,6 +22,7 @@ import {
     TableSelection,
     TableSorting,
 } from "./types";
+import { nullColumn } from "./utils/sorting";
 
 const useStyles = makeStyles({
     visuallyHidden: {
@@ -128,25 +129,27 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
                             )}
                         </TableCell>
                     )}
-                    {columns
-                        .filter(({ name }) => visibleColumns.includes(name))
-                        .map(column => (
-                            <TableCell
-                                key={`data-table-cell-${column.name}`}
-                                align="left"
-                                sortDirection={field === column.name ? order : false}
-                            >
-                                <TableSortLabel
-                                    active={field === column.name}
-                                    direction={order}
-                                    onClick={createSortHandler(column.name)}
-                                    IconComponent={ExpandMoreIcon}
-                                    disabled={column.sortable === false}
+                    {visibleColumns
+                        .map(vc => columns.find(c => c.name === vc) || nullColumn)
+                        .map(column => {
+                            return (
+                                <TableCell
+                                    key={`data-table-cell-${column.name}`}
+                                    align="left"
+                                    sortDirection={field === column.name ? order : false}
                                 >
-                                    {column.text}
-                                </TableSortLabel>
-                            </TableCell>
-                        ))}
+                                    <TableSortLabel
+                                        active={field === column.name}
+                                        direction={order}
+                                        onClick={createSortHandler(column.name as keyof T)}
+                                        IconComponent={ExpandMoreIcon}
+                                        disabled={column.sortable === false}
+                                    >
+                                        {column.text}
+                                    </TableSortLabel>
+                                </TableCell>
+                            );
+                        })}
                     <TableCell padding="none" align={"center"} onClick={openTableActions}>
                         {tableActions.length > 0 && (
                             <IconButton>

--- a/src/data-table/DataTableHeader.tsx
+++ b/src/data-table/DataTableHeader.tsx
@@ -22,7 +22,6 @@ import {
     TableSelection,
     TableSorting,
 } from "./types";
-import { nullColumn } from "./utils/sorting";
 
 const useStyles = makeStyles({
     visuallyHidden: {
@@ -59,6 +58,7 @@ export interface DataTableHeaderProps<T extends ReferenceObject> {
     enableMultipleAction: boolean;
     hideColumnVisibilityOptions?: boolean;
     hideSelectAll?: boolean;
+    allowReorderingColumns?: boolean;
 }
 
 export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeaderProps<T>) {
@@ -78,6 +78,7 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
         enableMultipleAction,
         hideColumnVisibilityOptions = false,
         hideSelectAll = false,
+        allowReorderingColumns,
     } = props;
 
     const { field, order } = sorting;
@@ -118,6 +119,7 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
                     visibleColumns={visibleColumns}
                     onChange={onVisibleColumnsChange || _.noop}
                     onCancel={() => setOpenColumnSettings(false)}
+                    allowReorderingColumns={allowReorderingColumns}
                 />
             )}
             <TableHead>
@@ -129,8 +131,9 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
                             )}
                         </TableCell>
                     )}
-                    {visibleColumns
-                        .map(vc => columns.find(c => c.name === vc) || nullColumn)
+                    {_(visibleColumns)
+                        .map(vc => columns.find(c => c.name === vc))
+                        .compact()
                         .map(column => {
                             return (
                                 <TableCell
@@ -149,7 +152,8 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
                                     </TableSortLabel>
                                 </TableCell>
                             );
-                        })}
+                        })
+                        .value()}
                     <TableCell padding="none" align={"center"} onClick={openTableActions}>
                         {tableActions.length > 0 && (
                             <IconButton>

--- a/src/data-table/DataTableHeader.tsx
+++ b/src/data-table/DataTableHeader.tsx
@@ -91,6 +91,10 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
         if (onSortingChange) onSortingChange({ field: property, order: isDesc ? "asc" : "desc" });
     };
 
+    const currentColumns = _.compact(
+        visibleColumns.map(column => columns.find(({ name }) => name === column))
+    );
+
     const tableActions = _.compact([
         !hideColumnVisibilityOptions
             ? {
@@ -131,29 +135,25 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
                             )}
                         </TableCell>
                     )}
-                    {_(visibleColumns)
-                        .map(vc => columns.find(c => c.name === vc))
-                        .compact()
-                        .map(column => {
-                            return (
-                                <TableCell
-                                    key={`data-table-cell-${column.name}`}
-                                    align="left"
-                                    sortDirection={field === column.name ? order : false}
+                    {currentColumns.map(column => {
+                        return (
+                            <TableCell
+                                key={`data-table-cell-${column.name}`}
+                                align="left"
+                                sortDirection={field === column.name ? order : false}
+                            >
+                                <TableSortLabel
+                                    active={field === column.name}
+                                    direction={order}
+                                    onClick={createSortHandler(column.name)}
+                                    IconComponent={ExpandMoreIcon}
+                                    disabled={column.sortable === false}
                                 >
-                                    <TableSortLabel
-                                        active={field === column.name}
-                                        direction={order}
-                                        onClick={createSortHandler(column.name as keyof T)}
-                                        IconComponent={ExpandMoreIcon}
-                                        disabled={column.sortable === false}
-                                    >
-                                        {column.text}
-                                    </TableSortLabel>
-                                </TableCell>
-                            );
-                        })
-                        .value()}
+                                    {column.text}
+                                </TableSortLabel>
+                            </TableCell>
+                        );
+                    })}
                     <TableCell padding="none" align={"center"} onClick={openTableActions}>
                         {tableActions.length > 0 && (
                             <IconButton>

--- a/src/data-table/TableColumnSelector.tsx
+++ b/src/data-table/TableColumnSelector.tsx
@@ -23,9 +23,6 @@ export function TableColumnSelector<T extends ReferenceObject>(props: TableColum
         const newSelection = !visibleColumns.includes(name)
             ? [...visibleColumns, name]
             : visibleColumns.filter(item => item !== name);
-
-        console.debug("NEW SELECTION");
-        console.debug(newSelection);
         onChange(newSelection);
     };
 

--- a/src/data-table/TableColumnSelector.tsx
+++ b/src/data-table/TableColumnSelector.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+
+import { ReferenceObject, TableColumn } from "..";
+import Table from "@material-ui/core/Table";
+import TableHead from "@material-ui/core/TableHead";
+import TableBody from "@material-ui/core/TableBody";
+import TableRow from "@material-ui/core/TableRow";
+import TableCell from "@material-ui/core/TableCell";
+import { Checkbox } from "@material-ui/core";
+
+import i18n from "../utils/i18n";
+
+interface TableColumnSelectorProps<T extends ReferenceObject> {
+    columns: TableColumn<T>[];
+    visibleColumns: (keyof T)[];
+    onChange: (visibleColumns: (keyof T)[]) => void;
+}
+
+export function TableColumnSelector<T extends ReferenceObject>(props: TableColumnSelectorProps<T>) {
+    const { columns, visibleColumns, onChange } = props;
+
+    const toggleElement = (name: keyof T) => {
+        const newSelection = !visibleColumns.includes(name)
+            ? [...visibleColumns, name]
+            : visibleColumns.filter(item => item !== name);
+
+        console.debug("NEW SELECTION");
+        console.debug(newSelection);
+        onChange(newSelection);
+    };
+
+    return (
+        <Table>
+            <TableHead>
+                <TableRow>
+                    <TableCell colSpan={12}>{i18n.t("Column")}</TableCell>
+                </TableRow>
+            </TableHead>
+            <TableBody>
+                {columns.map(({ name, text }) => {
+                    const checked = visibleColumns.includes(name);
+                    const disabled = visibleColumns.length <= 1 && checked;
+
+                    return (
+                        <TableRow key={`cell-${name}`}>
+                            <TableCell
+                                component="th"
+                                scope="row"
+                                onClick={() => !disabled && toggleElement(name)}
+                            >
+                                <Checkbox
+                                    color={"primary"}
+                                    checked={checked}
+                                    disabled={disabled}
+                                    tabIndex={-1}
+                                />
+                                {text}
+                            </TableCell>
+                        </TableRow>
+                    );
+                })}
+            </TableBody>
+        </Table>
+    );
+}

--- a/src/data-table/utils/sorting.tsx
+++ b/src/data-table/utils/sorting.tsx
@@ -20,6 +20,8 @@ export function sortObjects<T extends ReferenceObject>(
         .value();
 }
 
+export const nullColumn = { name: "", text: "", sortable: false };
+
 function getValue<T extends ReferenceObject>(
     row: T,
     column: TableColumn<T> | undefined,

--- a/src/data-table/utils/sorting.tsx
+++ b/src/data-table/utils/sorting.tsx
@@ -20,8 +20,6 @@ export function sortObjects<T extends ReferenceObject>(
         .value();
 }
 
-export const nullColumn = { name: "", text: "", sortable: false };
-
 function getValue<T extends ReferenceObject>(
     row: T,
     column: TableColumn<T> | undefined,

--- a/src/types/d2-ui.d.ts
+++ b/src/types/d2-ui.d.ts
@@ -1,0 +1,54 @@
+declare module "@dhis2/ui" {
+    export type TransferOption = {
+        label: string;
+        value: string;
+        disabled?: boolean;
+    };
+
+    export type TransferProps = {
+        options: TransferOption[];
+        onChange: (params: { selected: string[] }) => void;
+        addAllText?: string;
+        addIndividualText?: string;
+        className?: string;
+        dataTest?: string;
+        disabled?: boolean;
+        enableOrderChange?: boolean;
+        filterCallback?: (...args: any[]) => any;
+        filterCallbackPicked?: (...args: any[]) => any;
+        filterLabel?: string;
+        filterLabelPicked?: string;
+        filterPlaceholder?: string;
+        filterPlaceholderPicked?: string;
+        filterable?: boolean;
+        filterablePicked?: boolean;
+        height?: string;
+        hideFilterInput?: boolean;
+        hideFilterInputPicked?: boolean;
+        initialSearchTerm?: string;
+        initialSearchTermPicked?: string;
+        leftFooter?: React.ReactNode;
+        leftHeader?: React.ReactNode;
+        loading?: boolean;
+        loadingPicked?: boolean;
+        maxSelections?: any;
+        optionsWidth?: string;
+        removeAllText?: string;
+        removeIndividualText?: string;
+        renderOption?: (...args: any[]) => any;
+        rightFooter?: React.ReactNode;
+        rightHeader?: React.ReactNode;
+        searchTerm?: string;
+        searchTermPicked?: string;
+        selected?: string[];
+        selectedEmptyComponent?: React.ReactNode;
+        selectedWidth?: string;
+        sourceEmptyPlaceholder?: React.ReactNode;
+        onEndReached?: (...args: any[]) => any;
+        onEndReachedPicked?: (...args: any[]) => any;
+        onFilterChange?: (...args: any[]) => any;
+        onFilterChangePicked?: (...args: any[]) => any;
+    };
+
+    export function Transfer(props: TransferProps): React.ReactElement;
+}

--- a/src/types/d2-ui.d.ts
+++ b/src/types/d2-ui.d.ts
@@ -5,8 +5,8 @@ declare module "@dhis2/ui" {
         disabled?: boolean;
     };
 
-    export type TransferProps = {
-        options: TransferOption[];
+    export type TransferProps<T extends TransferOption> = {
+        options: T[];
         onChange: (params: { selected: string[] }) => void;
         addAllText?: string;
         addIndividualText?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1096,6 +1096,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.10.0", "@babel/runtime@^7.15.4":
+  version "7.16.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
+  integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7":
   version "7.12.5"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
@@ -1194,6 +1201,469 @@
   dependencies:
     "@date-io/core" "^1.0.2"
 
+"@dhis2-ui/alert@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/alert/-/alert-6.15.2.tgz#95d2de9ba0f316798d55339cb672ea632b470018"
+  integrity sha512-dDjHQ+5eWIPPTxBlWLIM3lPa/3Bd4DHenODi6pLsajMKKpSmrdqVo/AazQVYIqUWquVpZv2Cm/pqs4lmziNiNQ==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    "@dhis2/ui-icons" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/box@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/box/-/box-6.15.2.tgz#7b27190363ad9250a7ea092646ab11f39c86a9cb"
+  integrity sha512-HXAQcFDjwEgjM8ZPS49hbkfV/bTkjC/aqPuXyJ6mqPS6S7r5bl4zzGVhVOSmi5V81Lhspx5qr16b79t6TukJTg==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/button@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/button/-/button-6.15.2.tgz#bdf44efa7ebd17df031c75495c833b6f8c4a8cae"
+  integrity sha512-MIhCN3fxHNOrlRCXVNqAi+sgZYCPfFzE/2hbMNLAtRWOQTBNqnicwfGNtcJY2wzkhO+y/8OJilmY2pBjZBjY1A==
+  dependencies:
+    "@dhis2-ui/layer" "6.15.2"
+    "@dhis2-ui/loader" "6.15.2"
+    "@dhis2-ui/popper" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    "@dhis2/ui-icons" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/card@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/card/-/card-6.15.2.tgz#ac1db093fc1f3bc40fbca78f803e2a7d38dd69bb"
+  integrity sha512-y1KClCq1P9Kb5cqi/GgFeA593nrRnznXkK4mqW9xiygoB0R2ongPHSOAwJTSklff31Hzi9l2DIi1ZUgX871eaw==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/center@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/center/-/center-6.15.2.tgz#7e4461c165c30b87d629bf390f03e54e8dbcb2c8"
+  integrity sha512-pjXWJ5nbYwNpf0t8iy/7DVN+bJnvO8XWRz3uraS8NJ7IjhHtLl0sktpG0tIatiAzjrtO1QLD9ds0o4oRgT52MQ==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/checkbox@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/checkbox/-/checkbox-6.15.2.tgz#673d5f33025b4cb81984eb2c729eca5b14e12581"
+  integrity sha512-jM7KDsgq/fMOSoWTa08P3Qq6JzUM6zySsmCdEC4AHBmsD0u/2Eb1ktyv/BZQkPMx14lInSMtPsvcWCPaNtCtJg==
+  dependencies:
+    "@dhis2-ui/field" "6.15.2"
+    "@dhis2-ui/required" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/chip@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/chip/-/chip-6.15.2.tgz#8684980c993bb208eeca6bf625b112be346ac14c"
+  integrity sha512-G8DBc0EG2bIouZQ4uBWu5iB9QbWgX9WdPuGCnf6ZVIKQcM/NHFc74e2WW2XLrqqbpvm0xhNyopSAZhtZ+9YYzw==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/cover@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/cover/-/cover-6.15.2.tgz#a946e696b27f6b2425f67d8f97db83e998dbeca3"
+  integrity sha512-iyio99zj7X88kmFBKN94MY3KLEUfFfJaDpwrrq683igBaOyd8wqkLnu+rDE4v7sSklsQoeuficJFJoRwA3CDCw==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/css@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/css/-/css-6.15.2.tgz#82cdf63d42a00d4b1a9b6233c031e226898a2135"
+  integrity sha512-fCA0xMCHA4piMC3EcImBuC8/XR8rlBcBFWTITtOQGrE8yHsTfv+Ik8SF+j9sW/jfg7p9mZXt9s1KnT3uOdg2Kw==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/divider@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/divider/-/divider-6.15.2.tgz#009678eef72b1018849958b6d25572b29235ddc5"
+  integrity sha512-HCmrd5T7mK5YsVZO8fZDkYUBueuo5wdC8BGvY73s5PiwkQI0q1becj6dCjqGhaTlEY7z1RbXO0A/YQ62CkbDOQ==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/field@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/field/-/field-6.15.2.tgz#45939045db980fe1f6eb95c3c31aa3b59134a3ef"
+  integrity sha512-2b3gYg9W/gQlHiKoHHCsHbLF9WXjWPVkeRnBx1BF+E04rImbfwL6FPjin4RqtwJkskfW64/mVZW5V+Dn51cA6g==
+  dependencies:
+    "@dhis2-ui/box" "6.15.2"
+    "@dhis2-ui/help" "6.15.2"
+    "@dhis2-ui/label" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/file-input@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/file-input/-/file-input-6.15.2.tgz#18b170df11e89ed67af416f4d71d185dd5606fde"
+  integrity sha512-ehDgzscRp1m89My9Fk8EvgFUFuQyi7i1nhcFIGni+70vvmlPe/g4PvYSj8rju4MK3KR/2+7PoR6BLvyFE+H0LQ==
+  dependencies:
+    "@dhis2-ui/button" "6.15.2"
+    "@dhis2-ui/field" "6.15.2"
+    "@dhis2-ui/label" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/header-bar@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/header-bar/-/header-bar-6.15.2.tgz#5a0ef910759c955e28a9a6157010c0596e3edaf7"
+  integrity sha512-tZP54F6WWCTmO6HHbS2BvWKQVfFz1dYqCUir07XoLCFUhRsBcK325C/zASC6+PzrB24n7vLXS5jSdSMXSlX6Ew==
+  dependencies:
+    "@dhis2-ui/box" "6.15.2"
+    "@dhis2-ui/card" "6.15.2"
+    "@dhis2-ui/divider" "6.15.2"
+    "@dhis2-ui/input" "6.15.2"
+    "@dhis2-ui/logo" "6.15.2"
+    "@dhis2-ui/menu" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    "@dhis2/ui-icons" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/help@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/help/-/help-6.15.2.tgz#ad009f14fc1721b5b1d736e4b1662208d9453ff8"
+  integrity sha512-mNsmR0TjhunEgJ8et3r21Bw5Q3WQaB38g6nY9W8Nbjdxt4mBgXxNKsAxCSLYrAdcNdUDzaY/tCBGWqbVkRcdFg==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/input@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/input/-/input-6.15.2.tgz#f58a102ac5b35eca590c42af195c32aae1c6e891"
+  integrity sha512-Nt2bVJ21RAP5uDGoYbY+5joOjrcyQwBwjx7BOScLseC5Zb7MphRLmFGTxAy1kSIvl+9XFG/QTXS4lQTrXOYrlw==
+  dependencies:
+    "@dhis2-ui/box" "6.15.2"
+    "@dhis2-ui/field" "6.15.2"
+    "@dhis2-ui/input" "6.15.2"
+    "@dhis2-ui/loader" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    "@dhis2/ui-icons" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/intersection-detector@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/intersection-detector/-/intersection-detector-6.15.2.tgz#cf9db0a7826f7c454864e7ea801f3a9aec456226"
+  integrity sha512-tP6wqu09cZHg5tvNLJteozk+YQQ4iAt1i4uaJrv4SF+iSir0EJ3hOkNQuxgkqi1qMFzmu4IVtF8OhZS1iCE0Cg==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/label@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/label/-/label-6.15.2.tgz#c6e703c9b9f129f6f4419baf0ef7ad3c9a974126"
+  integrity sha512-xNq1jFwj33TJADyYzyN4C6JTQxuZscoY3tUi93Mh2a2Pl8h+tz9FhM+7cM9H4FfTbYZpttBCwsP2v08viYE7Sg==
+  dependencies:
+    "@dhis2-ui/required" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+
+"@dhis2-ui/layer@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/layer/-/layer-6.15.2.tgz#46eac6f539351fa63f3fe1e0351556cf68c19594"
+  integrity sha512-MGf5rMGUT5a8MgFOEgafYAriU0WBQmjpAghcAumOVG+qPUrKzn0Ao7Fo8FsNcrUfW5VsAZUiYrJPXl9HAvv6sw==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/legend@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/legend/-/legend-6.15.2.tgz#15f1d5ce387654147b4912fc180a17500e6323e4"
+  integrity sha512-miN75VfTU4SPA0kL1De5BBKot47NssRJRuohYlsIguEe2kqFZaP6mJBSsw+JG73PRX0eiCWjh6JEAEWX4Czuyw==
+  dependencies:
+    "@dhis2-ui/required" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/loader@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/loader/-/loader-6.15.2.tgz#e770f976acce4ff8c91c183f2f5e0b91faa93d0e"
+  integrity sha512-MZOzbDYYKOky62a/DVsNTmATmoWErgBDDyA+bdab0U2gvImHi9NjrRM3vbTMz6746BaX4ChqSPtvmXHB4zmZFw==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/logo@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/logo/-/logo-6.15.2.tgz#6750613acbcc71f9d2d3ce55f00994c41732deec"
+  integrity sha512-2sBAh1QOO3X95aGVocKn3HrrrynB66+iUV7dbmOMJPem8QiDLD+Fsa9y20DdGt0a4+I83SlFp1ao8mU6TGwDvg==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/menu@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/menu/-/menu-6.15.2.tgz#7cf5dd281b2e61240d58791dc840fcaff13f842d"
+  integrity sha512-bXzPz2PK5JGOIEV619gIaBHZkoo3MCGCWys/r3Vzut2Z/qO69F0gjc5kH6DXad0SKO6UIsR+cWfRehmcAKNewQ==
+  dependencies:
+    "@dhis2-ui/card" "6.15.2"
+    "@dhis2-ui/divider" "6.15.2"
+    "@dhis2-ui/layer" "6.15.2"
+    "@dhis2-ui/popper" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    "@dhis2/ui-icons" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/modal@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/modal/-/modal-6.15.2.tgz#4d92831584a1ec8f6dbd7756a3042a2aa5ffd099"
+  integrity sha512-2A/k3VEqgYguOe0bJyZzy95OfOUSEChkuvNx7cQ1dsSlyq8/Il7/w5CLsgBwSI+vNQu4gBqqMFQMcs0NQsDMRA==
+  dependencies:
+    "@dhis2-ui/card" "6.15.2"
+    "@dhis2-ui/center" "6.15.2"
+    "@dhis2-ui/layer" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/node@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/node/-/node-6.15.2.tgz#72ba545771af69dbfb6653d1aa8b4a2f606ba21d"
+  integrity sha512-IKA28wWMNRzoU8LycY4z4b/yA0ljxEvhIcZUKq+em164dKKIMdIIfxN9WbN9+TkpJKJpmCJ+E4yVBDb8amrJUw==
+  dependencies:
+    "@dhis2-ui/loader" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/notice-box@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/notice-box/-/notice-box-6.15.2.tgz#eb99e3a8af770bfad349d929f0fd0e0877c5d714"
+  integrity sha512-Vj4HyD+zzseza+SdboOneiq4gNsI3JFW5QygWoEiHk03qLweZuFkTczfPRokE46ns0TWEtH3zIeuCnQyFJataA==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    "@dhis2/ui-icons" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/organisation-unit-tree@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/organisation-unit-tree/-/organisation-unit-tree-6.15.2.tgz#90560588fbc3e92a524d2d2fbf8763f806fe5f1e"
+  integrity sha512-ibnOCWhZzw/rsdX8JNdqYd7XNYrf5ek4EcbeMHsD2ai7NCeZgaErbQCPdavEaWdvEOLNvXB1HAHcSV/THS9qsg==
+  dependencies:
+    "@dhis2-ui/checkbox" "6.15.2"
+    "@dhis2-ui/loader" "6.15.2"
+    "@dhis2-ui/node" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/pagination@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/pagination/-/pagination-6.15.2.tgz#f81dc3310e61d428a7fd8fd934551cb5da79f5d0"
+  integrity sha512-A9ZHWPfX0f4QRrwpsMfvnuM3gZktdW8fjwyW1yJj46FeP5iKg3U3ztV4T+2NjRxhjJBT/mnYWJ0viWgH+PsEEQ==
+  dependencies:
+    "@dhis2-ui/button" "6.15.2"
+    "@dhis2-ui/select" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    "@dhis2/ui-icons" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/popover@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/popover/-/popover-6.15.2.tgz#8c1a11f4a755d61596900139baf316673c7a8578"
+  integrity sha512-xIuYqVSoc6BrSiS11tTen4r92XJYgFhc4c97gD0UKkTKQS+AjonIx0MJRhjaTaCFrFGIcyq+Y1BGtV4mW6xhHw==
+  dependencies:
+    "@dhis2-ui/layer" "6.15.2"
+    "@dhis2-ui/popper" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/popper@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/popper/-/popper-6.15.2.tgz#1c62ba43c1376dcfb62df480782ad649b35cf43d"
+  integrity sha512-QZ06ACjy4NV04zp+6j9rd5SapDuBBSnu8OliQJ24bWPIcWIYC86N4HBKuRUiwfflT/j1zNfNWvM9IvoNrYscQg==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    "@popperjs/core" "^2.6.0"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+    react-popper "^2.2.5"
+    resize-observer-polyfill "^1.5.1"
+
+"@dhis2-ui/radio@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/radio/-/radio-6.15.2.tgz#eb2506f991f4053c074bc14e5b1fb5501d5ff340"
+  integrity sha512-zONnVmxehxX7UVdv59XYEQxXGKRg33hDHRKZTwdECuKvAguFM4XXcaRNqnQr1hBdTiOQocCPd+TUqV4xyukWcA==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/required@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/required/-/required-6.15.2.tgz#3cdff92ca19d8e053327e28bedc1f96f63caf102"
+  integrity sha512-ydZVBwm0gujka9bGmBb31SEqRAoLNcNHVBPjxv0S952CQsWaebOEY+baQS/3lIjb3gvEtWcIxc5UXO2+0FcuSQ==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/select@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/select/-/select-6.15.2.tgz#abe0d30483713bd3c592540f000a50a52a0799b2"
+  integrity sha512-VuRRXNIyBnhyeevLnrc6j29qFjD9MH0YdS0rmmjqddq0reAVT0gNyYQSWFOSOkaFxiKKYI7tRNE5GR0kHmEpdA==
+  dependencies:
+    "@dhis2-ui/box" "6.15.2"
+    "@dhis2-ui/button" "6.15.2"
+    "@dhis2-ui/card" "6.15.2"
+    "@dhis2-ui/checkbox" "6.15.2"
+    "@dhis2-ui/chip" "6.15.2"
+    "@dhis2-ui/field" "6.15.2"
+    "@dhis2-ui/input" "6.15.2"
+    "@dhis2-ui/layer" "6.15.2"
+    "@dhis2-ui/loader" "6.15.2"
+    "@dhis2-ui/popper" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    "@dhis2/ui-icons" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/switch@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/switch/-/switch-6.15.2.tgz#f06406b6882c22d660d425c15111ccfe0a971298"
+  integrity sha512-SxEmlvWIFZnd97PZkVKJyvrq+ftC+OAlF9Xa22mptAUYJr6XwykkkC9wd370fwiYHXCRVbqB+id963xkz1k4ZQ==
+  dependencies:
+    "@dhis2-ui/field" "6.15.2"
+    "@dhis2-ui/required" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/tab@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/tab/-/tab-6.15.2.tgz#f05a6ba4cfe06ee731887775d8ae2cdd4f3b6b67"
+  integrity sha512-/gGYcOQJYzrU/Lr3s7VrjA7va/unAVSDFTMETlgt9V3erQQ4t+OBk6p3JpLfuvrsdgZkXIreYbROicYmkqODAg==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    "@dhis2/ui-icons" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/table@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/table/-/table-6.15.2.tgz#a7b9578a0bbe7ebe52aa4a5d152d9b0668012fda"
+  integrity sha512-Fib8YfGSwMT+08dt4QtcrtoHKbTR/0i+HM4AEloJWUuBjF1E93aeC6yH4oDTQnxKH2vR6rvyQWgLQ54X87H3OA==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    "@dhis2/ui-icons" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/tag@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/tag/-/tag-6.15.2.tgz#b7943c7d6202af179ca978608822084bfef9661c"
+  integrity sha512-F3u70BS37+y5fU8kM5hSNdEDH8DAZ4HZASXPDxIqpSzOYFmHwd9h/K5k8Dx9E28RqKh1feY61mmfbom9/7RYzw==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/text-area@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/text-area/-/text-area-6.15.2.tgz#e7b575e053aeb4ff443140942886184aebe1ebf0"
+  integrity sha512-0BkNkc0dtFMfQalrPBpcj8SqFh275ZgkZjcnmjc1OSiGaDn22oYtQqL1/ER3TZYJRGPMGaXVfBjZOhkr939Zuw==
+  dependencies:
+    "@dhis2-ui/box" "6.15.2"
+    "@dhis2-ui/field" "6.15.2"
+    "@dhis2-ui/loader" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    "@dhis2/ui-icons" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/tooltip@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/tooltip/-/tooltip-6.15.2.tgz#c96b2a0623c6c9004a6cc544f899f8e5b4e0ad3e"
+  integrity sha512-gdpuMS/rOav/c7KHGGDz0VxQbxeVHIK/j9V3sl2H7s2uj+0FWMMA1RiPqEofFIiKsV+RRwrCK3faus7jai6HXw==
+  dependencies:
+    "@dhis2-ui/layer" "6.15.2"
+    "@dhis2-ui/popper" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2-ui/transfer@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/transfer/-/transfer-6.15.2.tgz#f0a99ac7840dae924ee824da6302a3f1aa5d8f14"
+  integrity sha512-DtY273nqsb25EKBcSrvm90o7vLu1EOiaoZI3ZaLuFVBOqCNpLm/fDJZqQngy6PbkWna57dyc78JYa/gAXyoUpg==
+  dependencies:
+    "@dhis2-ui/button" "6.15.2"
+    "@dhis2-ui/field" "6.15.2"
+    "@dhis2-ui/input" "6.15.2"
+    "@dhis2-ui/intersection-detector" "6.15.2"
+    "@dhis2-ui/loader" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
 "@dhis2/d2-i18n-extract@1.0.8":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n-extract/-/d2-i18n-extract-1.0.8.tgz#9d98690d522a51895c8ef3fe7136f026b0f8dacd"
@@ -1231,6 +1701,155 @@
     d2 "~31.7"
     lodash "^4.17.10"
     material-ui "^0.20.0"
+
+"@dhis2/prop-types@^1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-1.6.4.tgz#ec4d256c9440d4d00071524422a727c61ddaa6f6"
+  integrity sha512-qkVj8OuyjDmSxzYDlCWZllvC9hIbrIImMp79/U5CVsIRbjUF0zA/tfbv4rWnsWALmwEHOQFbzl5GnO5D8RNneA==
+  dependencies:
+    prop-types "^15"
+
+"@dhis2/ui-constants@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-6.15.2.tgz#3df26e9fa5683b87b85e75cc5b9c930ec2115b29"
+  integrity sha512-Ayprow4LPAbfyHcZ92KLSlSHgo7zRTa9aU+ZV/Ov3fjI+a9I7fJwgjvRXMBzZkS6NvuWFrHmOXkUMDreN7ZxAg==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    prop-types "^15.7.2"
+
+"@dhis2/ui-core@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-6.15.2.tgz#bafd358eae994de0c532d08951663ecd2331f736"
+  integrity sha512-3Ucpv9a2qcN4LYQywayW0Qtn2JVsNWXOivN5DjUHSlp62DGSwj9T1ZrThV3HznXNG4DqFSjD7pGetV1wDyOTvw==
+  dependencies:
+    "@dhis2-ui/alert" "6.15.2"
+    "@dhis2-ui/box" "6.15.2"
+    "@dhis2-ui/button" "6.15.2"
+    "@dhis2-ui/card" "6.15.2"
+    "@dhis2-ui/center" "6.15.2"
+    "@dhis2-ui/checkbox" "6.15.2"
+    "@dhis2-ui/chip" "6.15.2"
+    "@dhis2-ui/cover" "6.15.2"
+    "@dhis2-ui/css" "6.15.2"
+    "@dhis2-ui/divider" "6.15.2"
+    "@dhis2-ui/field" "6.15.2"
+    "@dhis2-ui/file-input" "6.15.2"
+    "@dhis2-ui/help" "6.15.2"
+    "@dhis2-ui/input" "6.15.2"
+    "@dhis2-ui/intersection-detector" "6.15.2"
+    "@dhis2-ui/label" "6.15.2"
+    "@dhis2-ui/layer" "6.15.2"
+    "@dhis2-ui/legend" "6.15.2"
+    "@dhis2-ui/loader" "6.15.2"
+    "@dhis2-ui/logo" "6.15.2"
+    "@dhis2-ui/menu" "6.15.2"
+    "@dhis2-ui/modal" "6.15.2"
+    "@dhis2-ui/node" "6.15.2"
+    "@dhis2-ui/notice-box" "6.15.2"
+    "@dhis2-ui/popover" "6.15.2"
+    "@dhis2-ui/popper" "6.15.2"
+    "@dhis2-ui/radio" "6.15.2"
+    "@dhis2-ui/required" "6.15.2"
+    "@dhis2-ui/select" "6.15.2"
+    "@dhis2-ui/switch" "6.15.2"
+    "@dhis2-ui/tab" "6.15.2"
+    "@dhis2-ui/table" "6.15.2"
+    "@dhis2-ui/tag" "6.15.2"
+    "@dhis2-ui/text-area" "6.15.2"
+    "@dhis2-ui/tooltip" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-constants" "6.15.2"
+    classnames "^2.3.1"
+    prop-types "^15.7.2"
+
+"@dhis2/ui-forms@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-6.15.2.tgz#cf3a0cfaa5b9f25c0ec471dddbc6ad068a6c5ce4"
+  integrity sha512-ob9cTmvcGUb0oO9TCuBdrH/oHgcGJ2LMAC04KYNbIok7LIbheQxnjpMhES5IXEFvMjr46IMw2X3xcspoyzLv3Q==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@dhis2/ui-core" "6.15.2"
+    "@dhis2/ui-widgets" "6.15.2"
+    classnames "^2.3.1"
+    final-form "^4.20.2"
+    prop-types "^15.7.2"
+    react-final-form "^6.5.3"
+
+"@dhis2/ui-icons@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-6.15.2.tgz#acc01f5e22afda910b6a0f4027702a87207a8725"
+  integrity sha512-jVGhFyC693UqU2M7hxfQc5d7laaDOnttLDJejy2iFcl3w9CoSM1LBBernX0r9r8OGeOrxZvThAJ+YoGJO1vlHQ==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+
+"@dhis2/ui-widgets@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-widgets/-/ui-widgets-6.15.2.tgz#64de32ed38cd601e100c2fb96c04feee9e673204"
+  integrity sha512-OKT1nuh7DdArhm9T+EXm5w8VdCCgeGiJ6GfMYsMV6YsSInbQTim4qZVsQ4zJWreQokjwTTwh/Y+1NXaL+GA8sA==
+  dependencies:
+    "@dhis2-ui/checkbox" "6.15.2"
+    "@dhis2-ui/field" "6.15.2"
+    "@dhis2-ui/file-input" "6.15.2"
+    "@dhis2-ui/header-bar" "6.15.2"
+    "@dhis2-ui/input" "6.15.2"
+    "@dhis2-ui/organisation-unit-tree" "6.15.2"
+    "@dhis2-ui/pagination" "6.15.2"
+    "@dhis2-ui/select" "6.15.2"
+    "@dhis2-ui/switch" "6.15.2"
+    "@dhis2-ui/table" "6.15.2"
+    "@dhis2-ui/text-area" "6.15.2"
+    "@dhis2-ui/transfer" "6.15.2"
+    "@dhis2/prop-types" "^1.6.4"
+    classnames "^2.3.1"
+
+"@dhis2/ui@6.15.2":
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-6.15.2.tgz#cdc86a7bf55bc0fc6725a94fcd2c7cd4642408b0"
+  integrity sha512-huVjhujg3FXeJ+0B2qrTtfColePA2ipi43Q+TpV0VUAD/yw1NtvLapeEl2LMGVg4jnYdhQyk9mNCdl/K9EOshQ==
+  dependencies:
+    "@dhis2-ui/alert" "6.15.2"
+    "@dhis2-ui/box" "6.15.2"
+    "@dhis2-ui/button" "6.15.2"
+    "@dhis2-ui/card" "6.15.2"
+    "@dhis2-ui/center" "6.15.2"
+    "@dhis2-ui/checkbox" "6.15.2"
+    "@dhis2-ui/chip" "6.15.2"
+    "@dhis2-ui/cover" "6.15.2"
+    "@dhis2-ui/css" "6.15.2"
+    "@dhis2-ui/divider" "6.15.2"
+    "@dhis2-ui/field" "6.15.2"
+    "@dhis2-ui/file-input" "6.15.2"
+    "@dhis2-ui/header-bar" "6.15.2"
+    "@dhis2-ui/help" "6.15.2"
+    "@dhis2-ui/input" "6.15.2"
+    "@dhis2-ui/intersection-detector" "6.15.2"
+    "@dhis2-ui/label" "6.15.2"
+    "@dhis2-ui/layer" "6.15.2"
+    "@dhis2-ui/legend" "6.15.2"
+    "@dhis2-ui/loader" "6.15.2"
+    "@dhis2-ui/logo" "6.15.2"
+    "@dhis2-ui/menu" "6.15.2"
+    "@dhis2-ui/modal" "6.15.2"
+    "@dhis2-ui/node" "6.15.2"
+    "@dhis2-ui/notice-box" "6.15.2"
+    "@dhis2-ui/organisation-unit-tree" "6.15.2"
+    "@dhis2-ui/pagination" "6.15.2"
+    "@dhis2-ui/popover" "6.15.2"
+    "@dhis2-ui/popper" "6.15.2"
+    "@dhis2-ui/radio" "6.15.2"
+    "@dhis2-ui/required" "6.15.2"
+    "@dhis2-ui/select" "6.15.2"
+    "@dhis2-ui/switch" "6.15.2"
+    "@dhis2-ui/tab" "6.15.2"
+    "@dhis2-ui/table" "6.15.2"
+    "@dhis2-ui/tag" "6.15.2"
+    "@dhis2-ui/text-area" "6.15.2"
+    "@dhis2-ui/tooltip" "6.15.2"
+    "@dhis2-ui/transfer" "6.15.2"
+    "@dhis2/ui-constants" "6.15.2"
+    "@dhis2/ui-forms" "6.15.2"
+    "@dhis2/ui-icons" "6.15.2"
+    prop-types "^15.7.2"
 
 "@emotion/hash@^0.8.0":
   version "0.8.0"
@@ -1569,6 +2188,11 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
+
+"@popperjs/core@^2.6.0":
+  version "2.10.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.2.tgz#0798c03351f0dea1a5a4cabddf26a55a7cbee590"
+  integrity sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.12"
@@ -2672,6 +3296,11 @@ classnames@2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
+classnames@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
 
 cliui@^5.0.0:
   version "5.0.0"
@@ -3815,6 +4444,13 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+final-form@^4.20.2:
+  version "4.20.4"
+  resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.20.4.tgz#8d59e36d3248a227265cc731d76c0564dd2606f6"
+  integrity sha512-hyoOVVilPLpkTvgi+FSJkFZrh0Yhy4BhE6lk/NiBwrF4aRV8/ykKEyXYvQH/pfUbRkOosvpESYouFb+FscsLrw==
+  dependencies:
+    "@babel/runtime" "^7.10.0"
 
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
@@ -6350,7 +6986,7 @@ prop-types@15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -6428,6 +7064,18 @@ react-event-listener@^0.6.2:
     prop-types "^15.6.0"
     warning "^4.0.1"
 
+react-fast-compare@^3.0.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-final-form@^6.5.3:
+  version "6.5.7"
+  resolved "https://registry.yarnpkg.com/react-final-form/-/react-final-form-6.5.7.tgz#0c1098accf0f0011adee5a46076ed1b99ed1b1ea"
+  integrity sha512-o7tvJXB+McGiXOILqIC8lnOcX4aLhIBiF/Xi9Qet35b7XOS8R7KL8HLRKTfnZWQJm6MCE15v1U0SFive0NcxyA==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+
 react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -6445,6 +7093,14 @@ react-linkify@1.0.0-alpha:
   dependencies:
     linkify-it "^2.0.3"
     tlds "^1.199.0"
+
+react-popper@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.5.tgz#1214ef3cec86330a171671a4fbcbeeb65ee58e96"
+  integrity sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==
+  dependencies:
+    react-fast-compare "^3.0.1"
+    warning "^4.0.2"
 
 react-test-renderer@^16.0.0-0:
   version "16.13.1"
@@ -6767,6 +7423,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"
@@ -7844,7 +8505,7 @@ warning@^3.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
-warning@^4.0.1:
+warning@^4.0.1, warning@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==


### PR DESCRIPTION
### :pushpin: References
-   **Issue:** Closes https://app.clickup.com/t/1kxx8pg

### :memo: Implementation
- Support options to pick visible/not visible columns only and more complex column visibility with ordering (via the Transfer component)
- By default, use Transfer, unless reorder property is false
- Some type checking is bypassed as there is a conflict between a `string[]` and a `(keyof T)[]` types
- This modification was requested for `d2-reports`. No code modification is needed
- Any other code that uses ColumnSelectorDialog should be tested to ensure the column ordering does not break anything
