### PR TITLE
[Fix] Initial state on table list

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.6.8",
+    "version": "2.6.9-beta.1",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/objects-list/objects-list-hooks.ts
+++ b/src/objects-list/objects-list-hooks.ts
@@ -7,6 +7,7 @@ import {
     TableAction,
     TableColumn,
     TablePagination,
+    TableSelection,
     TableSorting,
     TableState,
 } from "..";
@@ -90,7 +91,7 @@ export function useObjectsTable<Obj extends ReferenceObject>(
         async (sorting: TableSorting<Obj>, pagination: Partial<TablePagination>) => {
             setState(state => ({ ...state, isLoading: true }));
 
-            const paging = { ...initialPagination, ...pagination };
+            const paging = { ...initialState.pagination, ...pagination };
             const res = await getRows(search.trim(), paging, sorting);
             const ids = getAllIds ? await getAllIds(search.trim(), sorting) : undefined;
 
@@ -102,7 +103,7 @@ export function useObjectsTable<Obj extends ReferenceObject>(
                 ids,
             });
         },
-        [getRows, getAllIds, search, initialPagination]
+        [getRows, getAllIds, search, initialState.pagination]
     );
 
     const reload = useCallback(async () => {
@@ -110,8 +111,8 @@ export function useObjectsTable<Obj extends ReferenceObject>(
     }, [loadRows, state.sorting, state.pagination]);
 
     useEffect(() => {
-        loadRows(config.initialSorting, initialPagination);
-    }, [config.initialSorting, loadRows, initialPagination]);
+        loadRows(config.initialSorting, initialState.pagination);
+    }, [config.initialSorting, loadRows, initialState.pagination]);
 
     const onChange = useCallback(
         (newState: TableState<Obj>) => {

--- a/src/objects-list/objects-list-hooks.ts
+++ b/src/objects-list/objects-list-hooks.ts
@@ -16,12 +16,7 @@ import { ObjectsListProps } from "./ObjectsList";
 export interface TableConfig<Obj extends ReferenceObject>
     extends Omit<
         ObjectsTableProps<Obj>,
-        | "rows"
-        | "isLoading"
-        | "onChange"
-        | "pagination"
-        | "onChangeSearch"
-        | "reload"
+        "rows" | "isLoading" | "onChange" | "pagination" | "onChangeSearch" | "reload"
     > {
     columns: TableColumn<Obj>[];
     actions: TableAction<Obj>[];
@@ -68,9 +63,9 @@ export function useObjectsTable<Obj extends ReferenceObject>(
     const initialState = useMemo(
         () => ({
             pagination: {
-            page: 1,
-            pageSize: config.paginationOptions.pageSizeInitialValue ?? 20,
-            total: 0,
+                page: 1,
+                pageSize: config.paginationOptions.pageSizeInitialValue ?? 20,
+                total: 0,
             },
             sorting: config.initialSorting,
             selection: config.initialSelection,

--- a/src/objects-list/objects-list-hooks.ts
+++ b/src/objects-list/objects-list-hooks.ts
@@ -16,12 +16,18 @@ import { ObjectsListProps } from "./ObjectsList";
 export interface TableConfig<Obj extends ReferenceObject>
     extends Omit<
         ObjectsTableProps<Obj>,
-        "rows" | "isLoading" | "onChange" | "pagination" | "onChangeSearch" | "reload"
+        | "rows"
+        | "isLoading"
+        | "onChange"
+        | "pagination"
+        | "onChangeSearch"
+        | "reload"
     > {
     columns: TableColumn<Obj>[];
     actions: TableAction<Obj>[];
     paginationOptions: PaginationOptions;
     initialSorting: TableSorting<Obj>;
+    initialSelection?: TableSelection[];
     details?: ObjectsTableDetailField<Obj>[];
     searchBoxLabel?: string;
     initialSearch?: string;
@@ -52,19 +58,27 @@ export function useObjectsTable<Obj extends ReferenceObject>(
     config: TableConfig<Obj>,
     getRows: GetRows<Obj>
 ): ObjectsListProps<Obj> {
-    const initialPagination: TablePagination = useMemo(
+    const initialState = useMemo(
         () => ({
+            pagination: {
             page: 1,
             pageSize: config.paginationOptions.pageSizeInitialValue ?? 20,
             total: 0,
+            },
+            sorting: config.initialSorting,
+            selection: config.initialSelection,
         }),
-        [config.paginationOptions.pageSizeInitialValue]
+        [
+            config.initialSelection,
+            config.initialSorting,
+            config.paginationOptions.pageSizeInitialValue,
+        ]
     );
 
     const [state, setState] = useState<State<Obj>>(() => ({
         rows: undefined,
-        pagination: initialPagination,
-        sorting: config.initialSorting,
+        pagination: initialState.pagination,
+        sorting: initialState.sorting,
         isLoading: false,
     }));
 
@@ -109,5 +123,6 @@ export function useObjectsTable<Obj extends ReferenceObject>(
         searchBoxLabel: config.searchBoxLabel || i18n.t("Search by name"),
         onChangeSearch: setSearch,
         reload,
+        initialState,
     };
 }


### PR DESCRIPTION
- [Fix] Initial sorting for a column that is not the first was not set (leading to change re-ordering on selection)
- [Feature] Allow setting initial selection