### PR TITLE
Expose public types used in useObjectsTable

### DIFF
--- a/src/objects-list/objects-list-hooks.ts
+++ b/src/objects-list/objects-list-hooks.ts
@@ -36,13 +36,13 @@ export interface Pager {
     pageSize: number;
 }
 
-type GetRows<Obj extends ReferenceObject> = (
+export type GetRows<Obj extends ReferenceObject> = (
     search: string,
     paging: TablePagination,
     sorting: TableSorting<Obj>
 ) => Promise<{ objects: Obj[]; pager: Pager }>;
 
-type GetAllIds<Obj extends ReferenceObject> = (
+export type GetAllIds<Obj extends ReferenceObject> = (
     search: string,
     sorting: TableSorting<Obj>
 ) => Promise<string[]>;


### PR DESCRIPTION
Motivation: When using `useObjectsTable`, it's very handy to get access to the types of the hook's arguments. Note that typically you could hack it with `Parameters<typeof fn>[ARGINDEX]`, but here, being a generic function, it's not that useful (see https://github.com/microsoft/TypeScript/issues/37181).

Related: https://app.clickup.com/t/1vj3xp8