### PR TITLE
Add switch to OrgUnitsSelector to use orgUnit.shortName

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-07-07T22:41:42.386Z\n"
-"PO-Revision-Date: 2022-07-07T22:41:42.386Z\n"
+"POT-Creation-Date: 2022-07-11T04:52:08.113Z\n"
+"PO-Revision-Date: 2022-07-11T04:52:08.113Z\n"
 
 msgid "Cancel"
 msgstr ""
@@ -127,6 +127,9 @@ msgstr ""
 msgid "For all organisation units"
 msgstr ""
 
+msgid "Use short names"
+msgstr ""
+
 msgid "Remove"
 msgstr ""
 
@@ -179,7 +182,4 @@ msgid "Previous"
 msgstr ""
 
 msgid "Next"
-msgstr ""
-
-msgid "Use short names"
 msgstr ""

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-11-24T07:20:30.326Z\n"
-"PO-Revision-Date: 2021-11-24T07:20:30.326Z\n"
+"POT-Creation-Date: 2022-07-07T22:41:42.386Z\n"
+"PO-Revision-Date: 2022-07-07T22:41:42.386Z\n"
 
 msgid "Cancel"
 msgstr ""
@@ -179,4 +179,7 @@ msgid "Previous"
 msgstr ""
 
 msgid "Next"
+msgstr ""
+
+msgid "Use short names"
 msgstr ""

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2021-11-24T07:20:30.326Z\n"
+"POT-Creation-Date: 2022-07-07T22:41:42.386Z\n"
 "PO-Revision-Date: 2019-02-14T11:21:26.165Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -183,3 +183,6 @@ msgstr "Anterior"
 
 msgid "Next"
 msgstr "Siguiente"
+
+msgid "Use short names"
+msgstr "Usar nombres cortos"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2022-07-07T22:41:42.386Z\n"
+"POT-Creation-Date: 2022-07-11T04:52:08.113Z\n"
 "PO-Revision-Date: 2019-02-14T11:21:26.165Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -130,6 +130,9 @@ msgstr "Para unidades organizativas dentro de"
 msgid "For all organisation units"
 msgstr "Para todas las unidades organizativas"
 
+msgid "Use short names"
+msgstr "Usar nombres cortos"
+
 msgid "Remove"
 msgstr "Quitar"
 
@@ -183,6 +186,3 @@ msgstr "Anterior"
 
 msgid "Next"
 msgstr "Siguiente"
-
-msgid "Use short names"
-msgstr "Usar nombres cortos"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2021-11-24T07:20:30.326Z\n"
+"POT-Creation-Date: 2022-07-07T22:41:42.386Z\n"
 "PO-Revision-Date: 2019-02-14T11:21:26.165Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -183,3 +183,6 @@ msgstr "Précédent"
 
 msgid "Next"
 msgstr "Suivant"
+
+msgid "Use short names"
+msgstr "Utiliser noms courts"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2022-07-07T22:41:42.386Z\n"
+"POT-Creation-Date: 2022-07-11T04:52:08.113Z\n"
 "PO-Revision-Date: 2019-02-14T11:21:26.165Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -130,6 +130,9 @@ msgstr "Pour les unités d'organisation au sein de"
 msgid "For all organisation units"
 msgstr "Pour toutes les unités d'organisation"
 
+msgid "Use short names"
+msgstr "Utiliser noms courts"
+
 msgid "Remove"
 msgstr "Enlever"
 
@@ -183,6 +186,3 @@ msgstr "Précédent"
 
 msgid "Next"
 msgstr "Suivant"
-
-msgid "Use short names"
-msgstr "Utiliser noms courts"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.6.11",
+    "version": "2.6.12-beta.3",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/org-unit-tree/OrgUnitTree.component.js
+++ b/src/org-unit-tree/OrgUnitTree.component.js
@@ -50,7 +50,6 @@ class OrgUnitTree extends React.Component {
         super(props);
 
         this.state = {
-            useShortNames: props.useShortNames,
             children:
                 props.root.children === false ||
                 (Array.isArray(props.root.children) && props.root.children.length === 0)
@@ -273,7 +272,7 @@ class OrgUnitTree extends React.Component {
                         onClick={this.handleSelectClick}
                     />
                 )}
-                {this.state.useShortNames ? currentOu.shortName : currentOu.displayName}
+                {this.props.useShortNames ? currentOu.shortName : currentOu.displayName}
                 {hasChildren && !this.props.hideMemberCount && !!memberCount && (
                     <span style={styles.memberCount}>({memberCount})</span>
                 )}

--- a/src/org-unit-tree/OrgUnitTree.component.js
+++ b/src/org-unit-tree/OrgUnitTree.component.js
@@ -50,6 +50,7 @@ class OrgUnitTree extends React.Component {
         super(props);
 
         this.state = {
+            useShortNames: props.useShortNames,
             children:
                 props.root.children === false ||
                 (Array.isArray(props.root.children) && props.root.children.length === 0)
@@ -94,6 +95,7 @@ class OrgUnitTree extends React.Component {
                         id: true,
                         level: true,
                         displayName: true,
+                        shortName: true,
                         children: true,
                         path: true,
                         parent: true,
@@ -159,6 +161,7 @@ class OrgUnitTree extends React.Component {
                     hideMemberCount={this.props.hideMemberCount}
                     orgUnitsPathsToInclude={this.props.orgUnitsPathsToInclude}
                     selectableIds={this.props.selectableIds}
+                    useShortNames={this.props.useShortNames}
                 />
             );
         }
@@ -270,7 +273,7 @@ class OrgUnitTree extends React.Component {
                         onClick={this.handleSelectClick}
                     />
                 )}
-                {currentOu.displayName}
+                {this.state.useShortNames ? currentOu.shortName : currentOu.displayName}
                 {hasChildren && !this.props.hideMemberCount && !!memberCount && (
                     <span style={styles.memberCount}>({memberCount})</span>
                 )}

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -37,6 +37,7 @@ export default class OrgUnitsSelector extends React.Component {
         square: PropTypes.bool,
         singleSelection: PropTypes.bool,
         selectableIds: PropTypes.arrayOf(PropTypes.string),
+        showShortName: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -54,6 +55,7 @@ export default class OrgUnitsSelector extends React.Component {
         square: false,
         singleSelection: false,
         selectableIds: undefined,
+        showShortName: false,
     };
 
     static childContextTypes = {
@@ -321,18 +323,22 @@ export default class OrgUnitsSelector extends React.Component {
                         <div style={styles.contentItem}>
                             {roots.map(root => (
                                 <div key={root.path} className={`ou-root ${getClass(root)}`}>
-                                    <FormControlLabel
-                                        style={{ paddingLeft: "10px" }}
-                                        control={
-                                            <Switch
-                                                size="small"
-                                                onChange={() =>
-                                                    this.setState({ useShortNames: !useShortNames })
-                                                }
-                                            />
-                                        }
-                                        label={i18n.t("Use short names")}
-                                    />
+                                    {this.props.showShortName ? (
+                                        <FormControlLabel
+                                            style={{ paddingLeft: "10px" }}
+                                            control={
+                                                <Switch
+                                                    size="small"
+                                                    onChange={() =>
+                                                        this.setState({
+                                                            useShortNames: !useShortNames,
+                                                        })
+                                                    }
+                                                />
+                                            }
+                                            label={i18n.t("Use short names")}
+                                        />
+                                    ) : null}
                                     <OrgUnitTree
                                         key={useShortNames}
                                         api={api}

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -1,4 +1,4 @@
-import { Card, CardContent } from "@material-ui/core";
+import { Card, CardContent, FormControlLabel, Switch } from "@material-ui/core";
 import _ from "lodash";
 import PropTypes from "prop-types";
 import React from "react";
@@ -75,6 +75,7 @@ export default class OrgUnitsSelector extends React.Component {
                 orgUnitGroupId: null,
                 programId: null,
             },
+            useShortNames: false,
         };
         this.contentsStyle = { ...styles.contents, height: props.height };
     }
@@ -87,34 +88,34 @@ export default class OrgUnitsSelector extends React.Component {
             !filterByLevel
                 ? Promise.resolve([])
                 : props.api.models.organisationUnitLevels
-                      .get({
-                          paging: false,
-                          fields: { id: true, level: true, displayName: true },
-                          order: "level:asc",
-                          filter: { level: { in: props.levels } },
-                      })
-                      .getData()
-                      .then(({ objects }) => objects),
+                    .get({
+                        paging: false,
+                        fields: { id: true, level: true, displayName: true },
+                        order: "level:asc",
+                        filter: { level: { in: props.levels } },
+                    })
+                    .getData()
+                    .then(({ objects }) => objects),
             !filterByGroup
                 ? Promise.resolve([])
                 : props.api.models.organisationUnitGroups
-                      .get({
-                          pageSize: 1,
-                          paging: false,
-                          fields: { id: true, displayName: true },
-                      })
-                      .getData()
-                      .then(({ objects }) => objects),
+                    .get({
+                        pageSize: 1,
+                        paging: false,
+                        fields: { id: true, displayName: true },
+                    })
+                    .getData()
+                    .then(({ objects }) => objects),
             !filterByProgram
                 ? Promise.resolve([])
                 : props.api.models.programs
-                      .get({
-                          pageSize: 1,
-                          paging: false,
-                          fields: { id: true, displayName: true },
-                      })
-                      .getData()
-                      .then(({ objects }) => objects),
+                    .get({
+                        pageSize: 1,
+                        paging: false,
+                        fields: { id: true, displayName: true },
+                    })
+                    .getData()
+                    .then(({ objects }) => objects),
             this.getRoots(),
         ]).then(([levels, groups, programs, defaultRoots]) => {
             this.setState({
@@ -172,14 +173,14 @@ export default class OrgUnitsSelector extends React.Component {
         const { rootIds, selectableLevels } = this.props;
         const postFilter = search
             ? orgUnits =>
-                  _(orgUnits)
-                      .filter(orgUnit =>
-                          selectableLevels
-                              ? selectableLevels.includes(orgUnit.level)
-                              : !rootIds || rootIds.some(ouId => orgUnit.path.includes(ouId))
-                      )
-                      .take(50)
-                      .value()
+                _(orgUnits)
+                    .filter(orgUnit =>
+                        selectableLevels
+                            ? selectableLevels.includes(orgUnit.level)
+                            : !rootIds || rootIds.some(ouId => orgUnit.path.includes(ouId))
+                    )
+                    .take(50)
+                    .value()
             : _.identity;
 
         const response = this.queryRoots({ search });
@@ -273,7 +274,15 @@ export default class OrgUnitsSelector extends React.Component {
     render() {
         if (!this.state.levels) return null;
 
-        const { levels, currentRoot, roots, groups, programs, selectedFilters } = this.state;
+        const {
+            levels,
+            currentRoot,
+            roots,
+            groups,
+            programs,
+            selectedFilters,
+            useShortNames,
+        } = this.state;
         const {
             api,
             selected,
@@ -312,7 +321,20 @@ export default class OrgUnitsSelector extends React.Component {
                         <div style={styles.contentItem}>
                             {roots.map(root => (
                                 <div key={root.path} className={`ou-root ${getClass(root)}`}>
+                                    <FormControlLabel
+                                        style={{ paddingLeft: "10px" }}
+                                        control={
+                                            <Switch
+                                                size="small"
+                                                onChange={() =>
+                                                    this.setState({ useShortNames: !useShortNames })
+                                                }
+                                            />
+                                        }
+                                        label={i18n.t("Use short names")}
+                                    />
                                     <OrgUnitTree
+                                        key={useShortNames}
                                         api={api}
                                         root={root}
                                         selected={selected}
@@ -330,6 +352,7 @@ export default class OrgUnitsSelector extends React.Component {
                                         hideMemberCount={hideMemberCount}
                                         selectOnClick={selectOnClick}
                                         selectableIds={selectableIds}
+                                        useShortNames={useShortNames}
                                     />
                                 </div>
                             ))}

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -88,34 +88,34 @@ export default class OrgUnitsSelector extends React.Component {
             !filterByLevel
                 ? Promise.resolve([])
                 : props.api.models.organisationUnitLevels
-                    .get({
-                        paging: false,
-                        fields: { id: true, level: true, displayName: true },
-                        order: "level:asc",
-                        filter: { level: { in: props.levels } },
-                    })
-                    .getData()
-                    .then(({ objects }) => objects),
+                      .get({
+                          paging: false,
+                          fields: { id: true, level: true, displayName: true },
+                          order: "level:asc",
+                          filter: { level: { in: props.levels } },
+                      })
+                      .getData()
+                      .then(({ objects }) => objects),
             !filterByGroup
                 ? Promise.resolve([])
                 : props.api.models.organisationUnitGroups
-                    .get({
-                        pageSize: 1,
-                        paging: false,
-                        fields: { id: true, displayName: true },
-                    })
-                    .getData()
-                    .then(({ objects }) => objects),
+                      .get({
+                          pageSize: 1,
+                          paging: false,
+                          fields: { id: true, displayName: true },
+                      })
+                      .getData()
+                      .then(({ objects }) => objects),
             !filterByProgram
                 ? Promise.resolve([])
                 : props.api.models.programs
-                    .get({
-                        pageSize: 1,
-                        paging: false,
-                        fields: { id: true, displayName: true },
-                    })
-                    .getData()
-                    .then(({ objects }) => objects),
+                      .get({
+                          pageSize: 1,
+                          paging: false,
+                          fields: { id: true, displayName: true },
+                      })
+                      .getData()
+                      .then(({ objects }) => objects),
             this.getRoots(),
         ]).then(([levels, groups, programs, defaultRoots]) => {
             this.setState({
@@ -173,14 +173,14 @@ export default class OrgUnitsSelector extends React.Component {
         const { rootIds, selectableLevels } = this.props;
         const postFilter = search
             ? orgUnits =>
-                _(orgUnits)
-                    .filter(orgUnit =>
-                        selectableLevels
-                            ? selectableLevels.includes(orgUnit.level)
-                            : !rootIds || rootIds.some(ouId => orgUnit.path.includes(ouId))
-                    )
-                    .take(50)
-                    .value()
+                  _(orgUnits)
+                      .filter(orgUnit =>
+                          selectableLevels
+                              ? selectableLevels.includes(orgUnit.level)
+                              : !rootIds || rootIds.some(ouId => orgUnit.path.includes(ouId))
+                      )
+                      .take(50)
+                      .value()
             : _.identity;
 
         const response = this.queryRoots({ search });

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -38,6 +38,7 @@ export default class OrgUnitsSelector extends React.Component {
         singleSelection: PropTypes.bool,
         selectableIds: PropTypes.arrayOf(PropTypes.string),
         showShortName: PropTypes.bool,
+        showNameSetting: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -56,6 +57,7 @@ export default class OrgUnitsSelector extends React.Component {
         singleSelection: false,
         selectableIds: undefined,
         showShortName: false,
+        showNameSetting: false,
     };
 
     static childContextTypes = {
@@ -77,7 +79,7 @@ export default class OrgUnitsSelector extends React.Component {
                 orgUnitGroupId: null,
                 programId: null,
             },
-            useShortNames: false,
+            useShortNames: props.showShortName,
         };
         this.contentsStyle = { ...styles.contents, height: props.height };
     }
@@ -323,12 +325,13 @@ export default class OrgUnitsSelector extends React.Component {
                         <div style={styles.contentItem}>
                             {roots.map(root => (
                                 <div key={root.path} className={`ou-root ${getClass(root)}`}>
-                                    {this.props.showShortName ? (
+                                    {this.props.showNameSetting ? (
                                         <FormControlLabel
                                             style={{ paddingLeft: "10px" }}
                                             control={
                                                 <Switch
                                                     size="small"
+                                                    checked={useShortNames}
                                                     onChange={() =>
                                                         this.setState({
                                                             useShortNames: !useShortNames,


### PR DESCRIPTION
Reference ticket: https://app.clickup.com/t/2ghev8r

We want the OU tree to be able to show shortnames instead of just the
default displaynames. This commit adds a Switch inside a FormControlLabel
between the search box and the OU tree of the OrgUnitsSelector
component to do just that.

The trickiest part was adding:
  key={useShortNames}
to the OrgUnitTree component, because it not having a unique key before
meant that react never knew it had to update it after changing the
state of the OrgUnitsSelector component.