### PR TITLE
Removing sort icon if all columns are 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.6.12-beta.4",
+    "version": "2.6.12-beta.6",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.6.12-beta.3",
+    "version": "2.6.12-beta.4",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/data-table/DataTableHeader.tsx
+++ b/src/data-table/DataTableHeader.tsx
@@ -140,10 +140,12 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
                             <TableCell
                                 key={`data-table-cell-${column.name}`}
                                 align="left"
-                                sortDirection={field === column.name ? order : false}
+                                sortDirection={
+                                    field === column.name && column.sortable ? order : false
+                                }
                             >
                                 <TableSortLabel
-                                    active={field === column.name}
+                                    active={field === column.name && column.sortable}
                                     direction={order}
                                     onClick={createSortHandler(column.name)}
                                     IconComponent={ExpandMoreIcon}

--- a/src/data-table/DataTableHeader.tsx
+++ b/src/data-table/DataTableHeader.tsx
@@ -150,6 +150,7 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
                                     onClick={createSortHandler(column.name)}
                                     IconComponent={ExpandMoreIcon}
                                     disabled={column.sortable === false}
+                                    hideSortIcon={column.sortable === false}
                                 >
                                     {column.text}
                                 </TableSortLabel>


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [https://app.clickup.com/t/865c777eq](https://app.clickup.com/t/865c777eq)

### :memo: Implementation

Current implementation was not checking if the column has the sortable property as true. Also I added the **hideSortIcon** to hide the icon if the column is not active. Right now is still in the dom with opacity 0.

https://v4.mui.com/api/table-sort-label/#props

### :art: Screenshots

All columns with sortable = false
![table_no_sort](https://user-images.githubusercontent.com/461124/235233839-4776ca28-9b0a-4243-8aa8-ac7ffdd468b2.PNG)

All columns with sortable = true
![table_sort](https://user-images.githubusercontent.com/461124/235234224-69aac785-13dc-404a-a1af-7d7f31b7c564.PNG)

Dom without disabling the hideSortIcon prop
![table_icon_opacity_0](https://user-images.githubusercontent.com/461124/235234487-c4f56fa7-9cef-4e1c-a51c-f4af9f9ceb96.PNG)

Dom disabling the hideSortIcon if column is not sortable
![table_sortable_false_hide_icon](https://user-images.githubusercontent.com/461124/235234769-98e7fd60-4bda-443e-a615-4f21d9abd89a.PNG)



### :fire: Testing