### PR TITLE
fix: remove duplicate switch in org unit selector

### DIFF
--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -323,25 +323,25 @@ export default class OrgUnitsSelector extends React.Component {
 
                     <div style={this.contentsStyle}>
                         <div style={styles.contentItem}>
+                            {this.props.showNameSetting ? (
+                                <FormControlLabel
+                                    style={{ paddingLeft: "10px" }}
+                                    control={
+                                        <Switch
+                                            size="small"
+                                            checked={useShortNames}
+                                            onChange={() =>
+                                                this.setState({
+                                                    useShortNames: !useShortNames,
+                                                })
+                                            }
+                                        />
+                                    }
+                                    label={i18n.t("Use short names")}
+                                />
+                            ) : null}
                             {roots.map(root => (
                                 <div key={root.path} className={`ou-root ${getClass(root)}`}>
-                                    {this.props.showNameSetting ? (
-                                        <FormControlLabel
-                                            style={{ paddingLeft: "10px" }}
-                                            control={
-                                                <Switch
-                                                    size="small"
-                                                    checked={useShortNames}
-                                                    onChange={() =>
-                                                        this.setState({
-                                                            useShortNames: !useShortNames,
-                                                        })
-                                                    }
-                                                />
-                                            }
-                                            label={i18n.t("Use short names")}
-                                        />
-                                    ) : null}
                                     <OrgUnitTree
                                         key={useShortNames}
                                         api={api}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/865cwnu5t

### :memo: Implementation

### :art: Screenshots

### "Use short names" switch OFF after doing a search
![short-name-off](https://github.com/EyeSeeTea/d2-ui-components/assets/461124/4492ca95-5a71-4c7a-945a-566d13bc5845)

### "Use short names" switch ON after doing a search

![short-name-on](https://github.com/EyeSeeTea/d2-ui-components/assets/461124/30d39f3f-cdfb-411b-a2c6-3a1cd8301e7c)

### :fire: Testing
