### PR TITLE
reorder orgunit tree by shortName/displayName

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.7.0",
+    "version": "2.7.0_beta.2",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/org-unit-tree/OrgUnitTree.component.js
+++ b/src/org-unit-tree/OrgUnitTree.component.js
@@ -71,8 +71,10 @@ class OrgUnitTree extends React.Component {
     setChildState(children) {
         if (this.props.onChildrenLoaded) this.props.onChildrenLoaded(children);
 
+        const keyToOrder = this.props.useShortNames ? "shortName" : "displayName";
+
         this.setState({
-            children: children.sort((a, b) => a.displayName.localeCompare(b.displayName)),
+            children: children.sort((a, b) => a[keyToOrder].localeCompare(b[keyToOrder])),
             loading: false,
         });
     }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/860rub02b

### :memo: Implementation

### :video_camera: Screenshots/Screen capture

### **OrgUnit order by displayName**

![image](https://github.com/EyeSeeTea/d2-ui-components/assets/461124/42499cde-3c8b-4cfd-ad3a-264658513848)

### **OrgUnit order by shortName when "Use short names" switch is ON**

![image](https://github.com/EyeSeeTea/d2-ui-components/assets/461124/cdae9e91-04fa-4c9a-a234-638a79eda75d)

### :fire: Testing

can you please help me publishing a beta version in order to test this on Bulk Load? @tokland @adrianq @ifoche 
