### PR TITLE
notify if use short names switch change

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.7.0_beta.2",
+    "version": "2.7.0-beta.3",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -39,6 +39,7 @@ export default class OrgUnitsSelector extends React.Component {
         selectableIds: PropTypes.arrayOf(PropTypes.string),
         showShortName: PropTypes.bool,
         showNameSetting: PropTypes.bool,
+        onUseShortNamesChange: PropTypes.func,
     };
 
     static defaultProps = {
@@ -232,7 +233,10 @@ export default class OrgUnitsSelector extends React.Component {
         return currentRoot ? (
             <div>
                 {i18n.t("For organisation units within")}
-                <span style={styles.ouLabel}>{currentRoot.displayName}</span>:{" "}
+                <span style={styles.ouLabel}>
+                    {this.state.useShortNames ? currentRoot.shortName : currentRoot.displayName}
+                </span>
+                :{" "}
             </div>
         ) : (
             <div>{i18n.t("For all organisation units")}:</div>
@@ -273,6 +277,14 @@ export default class OrgUnitsSelector extends React.Component {
                 programId,
             },
         }));
+    };
+
+    onUseShortNamesChange = () => {
+        const newValue = !this.state.useShortNames;
+        this.setState({ useShortNames: newValue });
+        if (this.props.onUseShortNamesChange) {
+            this.props.onUseShortNamesChange(newValue);
+        }
     };
 
     render() {
@@ -330,11 +342,7 @@ export default class OrgUnitsSelector extends React.Component {
                                         <Switch
                                             size="small"
                                             checked={useShortNames}
-                                            onChange={() =>
-                                                this.setState({
-                                                    useShortNames: !useShortNames,
-                                                })
-                                            }
+                                            onChange={this.onUseShortNamesChange}
                                         />
                                     }
                                     label={i18n.t("Use short names")}


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/860ryt00g

### :memo: Implementation

- Adding function prop **onUseShortNamesChange** so we can know the current value of the **Use short names** switch.

This is for bulk load because we need to know the current value of the switch in order to generate the org units metadata using the **displayName** or **displayShortName** property in templates.

### :fire: Notes for the reviewer

@ifoche can you help me publishing a new beta version for bulk load, please?

### :video_camera: Screenshots/Screen capture
