### PR TITLE
add completed prop for wizard

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.7.0-beta.3",
+    "version": "2.7.0-beta.4",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/wizard/Stepper.tsx
+++ b/src/wizard/Stepper.tsx
@@ -27,7 +27,7 @@ export const Stepper: React.FC<StepperProps> = ({
             {steps.map((step, index) => (
                 <Step
                     key={step.key}
-                    completed={false}
+                    completed={step.completed || false}
                     disabled={index > lastClickableStepIndex}
                     className={"Wizard-Step"}
                 >

--- a/src/wizard/Wizard.tsx
+++ b/src/wizard/Wizard.tsx
@@ -162,6 +162,7 @@ const useStyles = makeStyles(() => ({
 }));
 
 export interface WizardStep {
+    completed?: boolean;
     key: string;
     label: string;
     warning?: string;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8693muw6j

### :memo: Implementation

In the data quality app we need a way to indicate that a step is already completed. The `<Step />` already has support for this, but right now the value is hardcoded to `false`. I'm adding a new prop to give users the control of this behavior.

This is how it looks when the prop `completed` is true:

![image](https://github.com/EyeSeeTea/d2-ui-components/assets/461124/a0541ace-323b-4c48-9081-0e47520a94bb)

### :video_camera: Screenshots/Screen capture

**Wizard with step "Summary" mark as completed**
![image](https://github.com/EyeSeeTea/d2-ui-components/assets/461124/d3e73a2b-cdc1-4bf8-8ab5-085974ee324b)

### :fire: Notes to the tester

@adrianq @ifoche can you help publishing a new beta version for this please?