### PR TITLE
filter org. units by selectableLevels

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.8.0",
+    "version": "2.9.0-beta.2",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.8.0",
+    "version": "2.9.0-beta.1",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -1,3 +1,4 @@
+import classnames from "classnames";
 import { CircularProgress } from "@material-ui/core";
 import Paper from "@material-ui/core/Paper";
 import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
@@ -103,11 +104,15 @@ export interface DataTableProps<T extends ReferenceObject> {
     resetKey?: string;
     selectionMessages?: SelectionMessages;
     onReorderColumns?(columns: Array<keyof T>): void;
+    customClasses?: CustomClassesType;
+    stickyHeader?: boolean;
 }
 
 export function DataTable<T extends ReferenceObject = TableObject>(props: DataTableProps<T>) {
     const classes = useStyles();
     const {
+        customClasses,
+        stickyHeader,
         rows,
         columns,
         rowConfig = defaultRowConfig,
@@ -261,7 +266,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
 
     return (
         <div className={classes.root}>
-            <Toolbar className={classes.toolbar}>
+            <Toolbar className={classnames(classes.toolbar, customClasses?.toolbar)}>
                 <React.Fragment>
                     {filterComponents}
                     <div className={classes.spacer}></div>
@@ -273,9 +278,9 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
                     )}
                 </React.Fragment>
             </Toolbar>
-            <div className={classes.tableWrapper}>
-                <Paper className={classes.paper} square>
-                    <Table className={classes.table} size={"medium"}>
+            <div className={classnames(classes.tableWrapper, customClasses?.tableWrapper)}>
+                <Paper className={classnames(classes.paper, customClasses?.paper)} square>
+                    <Table stickyHeader={stickyHeader} className={classes.table} size={"medium"}>
                         <DataTableHeader
                             columns={columns}
                             globalActions={globalActions}
@@ -338,3 +343,6 @@ const defaultRenderPosition: NonNullable<PaginationOptions["renderPosition"]> = 
     top: true,
     bottom: false,
 };
+
+type CssClassName = string;
+type CustomClassesType = { toolbar: CssClassName; paper: CssClassName; tableWrapper: CssClassName };

--- a/src/org-unit-select/OrgUnitSelectAll.component.js
+++ b/src/org-unit-select/OrgUnitSelectAll.component.js
@@ -52,8 +52,13 @@ class OrgUnitSelectAll extends React.Component {
         } else {
             this.setState({ loading: true });
 
+            const filters =
+                this.props.selectableLevels && this.props.selectableLevels.length > 0
+                    ? { level: { in: this.props.selectableLevels } }
+                    : undefined;
+
             this.context.api.models.organisationUnits
-                .get({ fields: { id: true, path: true }, paging: false })
+                .get({ fields: { id: true, path: true }, paging: false, filter: filters })
                 .getData()
                 .then(({ objects }) => {
                     this.addToSelection(objects);

--- a/src/org-unit-select/OrgUnitSelectAll.component.js
+++ b/src/org-unit-select/OrgUnitSelectAll.component.js
@@ -5,6 +5,7 @@ import Button from "@material-ui/core/Button";
 import i18n from "../utils/i18n";
 
 import { addToSelection, removeFromSelection } from "./common";
+import { isSelectableLevelsDefined } from "./OrgUnitSelectByGroup.component";
 
 const style = {
     button: {
@@ -52,10 +53,9 @@ class OrgUnitSelectAll extends React.Component {
         } else {
             this.setState({ loading: true });
 
-            const filters =
-                this.props.selectableLevels && this.props.selectableLevels.length > 0
-                    ? { level: { in: this.props.selectableLevels } }
-                    : undefined;
+            const filters = isSelectableLevelsDefined(this.props.selectableLevels)
+                ? { level: { in: this.props.selectableLevels } }
+                : undefined;
 
             this.context.api.models.organisationUnits
                 .get({ fields: { id: true, path: true }, paging: false, filter: filters })

--- a/src/org-unit-select/OrgUnitSelectByGroup.component.js
+++ b/src/org-unit-select/OrgUnitSelectByGroup.component.js
@@ -10,9 +10,8 @@ import {
     renderDropdown,
 } from "./common";
 
-function isSelectableLevelsDefined(selectableLevels) {
-    if (!selectableLevels || selectableLevels.length === 0) return undefined;
-    return selectableLevels;
+export function isSelectableLevelsDefined(selectableLevels) {
+    return !selectableLevels || selectableLevels.length === 0 ? undefined : selectableLevels;
 }
 
 class OrgUnitSelectByGroup extends React.Component {

--- a/src/org-unit-select/OrgUnitSelectByGroup.component.js
+++ b/src/org-unit-select/OrgUnitSelectByGroup.component.js
@@ -10,6 +10,11 @@ import {
     renderDropdown,
 } from "./common";
 
+function isSelectableLevelsDefined(selectableLevels) {
+    if (!selectableLevels || selectableLevels.length === 0) return undefined;
+    return selectableLevels;
+}
+
 class OrgUnitSelectByGroup extends React.Component {
     constructor(props, context) {
         super(props, context);
@@ -63,7 +68,7 @@ class OrgUnitSelectByGroup extends React.Component {
                 const { api } = this.context;
                 api.models.organisationUnitGroups
                     .get({
-                        fields: { organisationUnits: { id: true, path: true } },
+                        fields: { organisationUnits: { id: true, path: true, level: true } },
                         filter: { id: { eq: groupId } },
                     })
                     .getData()
@@ -73,10 +78,17 @@ class OrgUnitSelectByGroup extends React.Component {
                             `Loaded ${organisationUnits.length} org units for group ${groupId}`
                         );
                         this.setState({ loading: false });
-                        this.groupCache[groupId] = organisationUnits;
-
+                        const levelsToFilter = isSelectableLevelsDefined(
+                            this.props.selectableLevels
+                        );
+                        const filterOrgUnits = levelsToFilter
+                            ? organisationUnits.filter(orgUnit =>
+                                  levelsToFilter.includes(orgUnit.level)
+                              )
+                            : organisationUnits;
+                        this.groupCache[groupId] = filterOrgUnits;
                         // Make a copy of the returned array to ensure that the cache won't be modified from elsewhere
-                        resolve(organisationUnits.slice());
+                        resolve(filterOrgUnits);
                     })
                     .catch(err => {
                         this.setState({ loading: false });

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -408,6 +408,7 @@ export default class OrgUnitsSelector extends React.Component {
                                                         }
                                                         onItemSelection={this.changeOrgUnitGroup}
                                                         selectableIds={selectableIds}
+                                                        selectableLevels={selectableLevels}
                                                     />
                                                 </div>
                                             )}
@@ -437,6 +438,7 @@ export default class OrgUnitsSelector extends React.Component {
                                                 onUpdateSelection={this.handleSelectionUpdate}
                                                 selectableIds={selectableIds}
                                                 selectedFilters={selectedFilters}
+                                                selectableLevels={selectableLevels}
                                             />
                                         </div>
                                     )}

--- a/src/wizard/Stepper.tsx
+++ b/src/wizard/Stepper.tsx
@@ -4,6 +4,14 @@ import React, { MouseEvent } from "react";
 import { Help } from "./Help";
 import { WizardStep } from "./Wizard";
 
+const currentStepClassName = "current-step";
+
+function mergeStepClasses(className: string | undefined, isActive: boolean): string {
+    return _([isActive ? currentStepClassName : undefined, className])
+        .compact()
+        .join(" ");
+}
+
 export const Stepper: React.FC<StepperProps> = ({
     steps,
     lastClickableStepIndex = 0,
@@ -29,14 +37,15 @@ export const Stepper: React.FC<StepperProps> = ({
                     key={step.key}
                     completed={step.completed || false}
                     disabled={index > lastClickableStepIndex}
-                    className={"Wizard-Step"}
+                    className={_(["Wizard-Step", step.stepClassName]).compact().value().join(" ")}
                 >
                     <StepButton
                         key={step.key}
+                        {...(step.icon ? { icon: step.icon } : {})}
                         data-test-current={currentStep === step}
                         onClick={onStepClicked ? onStepClicked(step.key) : undefined}
                         classes={{ root: classes.stepButton }}
-                        className={currentStep === step ? "current-step" : ""}
+                        className={mergeStepClasses(step.stepButtonClassName, currentStep === step)}
                     >
                         {step.label}
                     </StepButton>

--- a/src/wizard/Wizard.tsx
+++ b/src/wizard/Wizard.tsx
@@ -171,6 +171,9 @@ export interface WizardStep {
     props?: object;
     help?: React.ReactNode;
     helpDialogIsInitialOpen?: boolean;
+    icon?: React.ReactNode;
+    stepClassName?: string;
+    stepButtonClassName?: string;
 }
 
 export interface WizardProps {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/86945xe2m

### :memo: Implementation

Right now if you're using the `OrgUnitsSelector` component with the `selectableLevels` prop to limit the org units.

```tsx
<OrgUnitsSelector
    selectableLevels={[1, 2]}
 />
```

it'll render this:

![image](https://github.com/EyeSeeTea/d2-ui-components/assets/461124/54b2d761-bf66-417f-b642-8c6daaf9e2e5)

which is correct, but if you click on the `SELECT ALL` button it won't apply the `selectableLevels` value to filter the selected org units:

![image](https://github.com/EyeSeeTea/d2-ui-components/assets/461124/89a05ee7-f866-433f-8916-a62239201f18)

which could be confusing because initially you only want to work with org. units in levels 1 and 2. Same case for the `SELECT` button in the Organisation Group selector.

This PR change the behavior so the `selectableLevels` is being considered in the selected org units.

[UPDATE 2024-04-01]

I'm including another feature for the Wizard component in order to have custom icons for each step.

[UPDATE 2024-05-02]
Adding props to add custom css and sticky headers to the `DataTable` component

![image](https://github.com/EyeSeeTea/d2-ui-components/assets/461124/6f6df6a3-5d29-4152-af1a-daeab02a9096)
I'm reusing the same PR because I need both changes in the same app, but let me know if I should create another PR.

### :video_camera: Screenshots/Screen capture

**Selector with `selectableLevels={[1, 2]}` (current behavior)**
[Data-Quality_selectable_orgunits_before_fix.webm](https://github.com/EyeSeeTea/d2-ui-components/assets/461124/e531c28e-4d0e-46a5-ac2f-907f952a7022)

**Selector with `selectableLevels={[1, 2]}` (new behavior)**
[Data-Quality_selectable_orgunits.webm](https://github.com/EyeSeeTea/d2-ui-components/assets/461124/d6862dd1-2fcd-4f6d-a6fe-b8817532f36d)

**Custom icons for each step in wizard**
![image](https://github.com/EyeSeeTea/d2-ui-components/assets/461124/c4b5306d-bc62-4dde-8277-bf69a6bbe998)

### :fire: Notes to the tester

#86945xe2m