### PR TITLE
feature: new callback `onChildrenLoaded` to get children when new OrgUnit is selected

### DIFF
--- a/src/org-unit-tree/OrgUnitTree.component.js
+++ b/src/org-unit-tree/OrgUnitTree.component.js
@@ -69,7 +69,7 @@ class OrgUnitTree extends React.Component {
     }
 
     setChildState(children) {
-        if (this.props.onChildrenLoaded) this.props.onChildrenLoaded(children);
+        if (this.props.onChildrenLoaded) this.props.onChildrenLoaded.fn(children);
 
         const keyToOrder = this.props.useShortNames ? "shortName" : "displayName";
 
@@ -80,7 +80,7 @@ class OrgUnitTree extends React.Component {
     }
 
     loadChildren() {
-        const { root, api, idsThatShouldBeReloaded } = this.props;
+        const { root, api, idsThatShouldBeReloaded, onChildrenLoaded } = this.props;
 
         if (
             (this.state.children === undefined && !this.state.loading) ||
@@ -89,19 +89,26 @@ class OrgUnitTree extends React.Component {
             this.setState({ loading: true });
 
             const childrenIds = root.children.map(({ id }) => id);
+            const fields = {
+                id: true,
+                level: true,
+                displayName: true,
+                shortName: true,
+                children: true,
+                path: true,
+                parent: true,
+            };
+
+            if (onChildrenLoaded?.fields) {
+                onChildrenLoaded.fields.forEach(field => {
+                    fields[field] = true;
+                });
+            }
+
             api.models.organisationUnits
                 .get({
                     paging: false,
-                    fields: {
-                        id: true,
-                        level: true,
-                        displayName: true,
-                        shortName: true,
-                        children: true,
-                        path: true,
-                        parent: true,
-                        geometry: true,
-                    },
+                    fields,
                     filter: {
                         id: {
                             in: childrenIds,
@@ -111,6 +118,10 @@ class OrgUnitTree extends React.Component {
                 .getData()
                 .then(({ objects }) => {
                     this.setChildState(objects);
+
+                    if (onChildrenLoaded?.fn) {
+                        onChildrenLoaded.fn(objects);
+                    }
                 });
         }
     }
@@ -376,11 +387,16 @@ OrgUnitTree.propTypes = {
     currentRoot: PropTypes.object,
 
     /**
-     * onChildrenLoaded callback, which is triggered when the children of this root org unit have been loaded
+     * onChildrenLoaded is a callback depending on a field, which is triggered when the children of this root org unit have been loaded
      *
-     * The callback receives one argument: An array that contains all the newly loaded org units
+     * The callback receives two argument:
+     * - A fields array that needs to be fetched
+     * - A callback wich get an array that contains all the newly loaded org units
      */
-    onChildrenLoaded: PropTypes.func,
+    onChildrenLoaded: PropTypes.shape({
+        fields: PropTypes.arrayOf(PropTypes.string),
+        fn: PropTypes.func,
+    }),
 
     /**
      * Custom styling for OU labels

--- a/src/org-unit-tree/OrgUnitTree.component.js
+++ b/src/org-unit-tree/OrgUnitTree.component.js
@@ -100,6 +100,7 @@ class OrgUnitTree extends React.Component {
                         children: true,
                         path: true,
                         parent: true,
+                        geometry: true,
                     },
                     filter: {
                         id: {

--- a/src/org-unit-tree/OrgUnitTree.component.js
+++ b/src/org-unit-tree/OrgUnitTree.component.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import _ from "lodash";
 import { LinearProgress } from "@material-ui/core";
 
 import { TreeView } from "@dhis2/d2-ui-core";
@@ -89,6 +90,11 @@ class OrgUnitTree extends React.Component {
             this.setState({ loading: true });
 
             const childrenIds = root.children.map(({ id }) => id);
+            const extraFields = _(onChildrenLoaded.fields || [])
+                .map(field => [field, true])
+                .fromPairs()
+                .value();
+
             const fields = {
                 id: true,
                 level: true,
@@ -97,13 +103,8 @@ class OrgUnitTree extends React.Component {
                 children: true,
                 path: true,
                 parent: true,
+                ...extraFields,
             };
-
-            if (onChildrenLoaded?.fields) {
-                onChildrenLoaded.fields.forEach(field => {
-                    fields[field] = true;
-                });
-            }
 
             api.models.organisationUnits
                 .get({

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -40,6 +40,7 @@ export default class OrgUnitsSelector extends React.Component {
         showShortName: PropTypes.bool,
         showNameSetting: PropTypes.bool,
         onUseShortNamesChange: PropTypes.func,
+        onChildrenLoaded: PropTypes.func,
     };
 
     static defaultProps = {
@@ -141,6 +142,7 @@ export default class OrgUnitsSelector extends React.Component {
                 displayName: true,
                 path: true,
                 children: true,
+                geometry: true,
             },
             ...listParams,
         };
@@ -225,6 +227,10 @@ export default class OrgUnitsSelector extends React.Component {
         this.setState(state => ({
             roots: state.roots.map(r => (r.path === root.path ? mergeChildren(r, children) : r)),
         }));
+
+        if (this.props.onChildrenLoaded) {
+            this.props.onChildrenLoaded(children);
+        }
     };
 
     renderOrgUnitSelectTitle = () => {

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -40,7 +40,10 @@ export default class OrgUnitsSelector extends React.Component {
         showShortName: PropTypes.bool,
         showNameSetting: PropTypes.bool,
         onUseShortNamesChange: PropTypes.func,
-        onChildrenLoaded: PropTypes.func,
+        onChildrenLoaded: PropTypes.shape({
+            fields: PropTypes.arrayOf(PropTypes.string),
+            fn: PropTypes.func,
+        }),
     };
 
     static defaultProps = {
@@ -228,8 +231,8 @@ export default class OrgUnitsSelector extends React.Component {
             roots: state.roots.map(r => (r.path === root.path ? mergeChildren(r, children) : r)),
         }));
 
-        if (this.props.onChildrenLoaded) {
-            this.props.onChildrenLoaded(children);
+        if (this.props.onChildrenLoaded?.fn) {
+            this.props.onChildrenLoaded.fn(children);
         }
     };
 
@@ -367,10 +370,17 @@ export default class OrgUnitsSelector extends React.Component {
                                         selectableLevels={selectableLevels}
                                         typeInput={typeInput}
                                         onChangeCurrentRoot={this.changeRoot}
-                                        onChildrenLoaded={this.handleChildrenLoaded.bind(
-                                            this,
-                                            root
-                                        )}
+                                        onChildrenLoaded={
+                                            this.props.onChildrenLoaded
+                                                ? {
+                                                      fields: this.props.onChildrenLoaded.fields,
+                                                      fn: this.handleChildrenLoaded.bind(
+                                                          this,
+                                                          root
+                                                      ),
+                                                  }
+                                                : undefined
+                                        }
                                         hideCheckboxes={hideCheckboxes}
                                         hideMemberCount={hideMemberCount}
                                         selectOnClick={selectOnClick}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** [Closes](https://app.clickup.com/t/86957kfzj) #86957kfzj

### :memo: Implementation

New callback `onChildrenLoaded` to get children when new OrgUnit is selected `OrgUnitsSelector` component with the `selectableLevels` prop to limit the org units. Purpose of this was to get only displayed OrgUnits ids for filtering with selectableIds.

```tsx
const onChildrenLoaded = (orgUnits: OrgUnits[]) => useCallback({
	// Here you can filter with orgUnits props
	// Ex: filter on geometry
	setSelectableIds(orgUnits.filter(child => !!child.geometry).map(child => child.id))
}, [orgUnitsWithCoordinates])

<OrgUnitsSelector
    onChildrenLoaded={onChildrenLoaded}
	selectableIds={selectableIds}
 />
```

### :video_camera: Screenshots/Screen capture
https://github.com/user-attachments/assets/3055ce5f-7064-44ea-abb8-4aa140561cab


### :fire: Notes to the tester