### PR TITLE
Added slot for children in orgunit label and disabled state prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
         "@material-ui/core": "4",
         "@material-ui/icons": "4",
         "d2": "31",
-        "react": "16",
-        "react-dom": "16"
+        "react": ">=16",
+        "react-dom": ">=16"
     },
     "devDependencies": {
         "@babel/cli": "7.12.10",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
         "@types/jest": "26.0.20",
         "@types/lodash": "4.14.168",
         "@types/material-ui": "0.21.8",
+        "@types/react": "17.0.43",
+        "@types/react-dom": "17.0.14",
         "@types/react-linkify": "1.0.0",
         "@typescript-eslint/eslint-plugin": "4.14.0",
         "@typescript-eslint/parser": "4.14.0",

--- a/src/org-unit-tree/OrgUnitTree.component.js
+++ b/src/org-unit-tree/OrgUnitTree.component.js
@@ -173,6 +173,7 @@ class OrgUnitTree extends React.Component {
                     currentRoot={this.props.currentRoot}
                     onChangeCurrentRoot={this.props.onChangeCurrentRoot}
                     labelStyle={this.props.labelStyle}
+                    labelChildren={this.props.labelChildren}
                     selectedLabelStyle={this.props.selectedLabelStyle}
                     arrowSymbol={this.props.arrowSymbol}
                     idsThatShouldBeReloaded={this.props.idsThatShouldBeReloaded}
@@ -297,6 +298,7 @@ class OrgUnitTree extends React.Component {
                 {hasChildren && !this.props.hideMemberCount && !!memberCount && (
                     <span style={styles.memberCount}>({memberCount})</span>
                 )}
+                {this.props.labelChildren && this.props.labelChildren({ currentOu: currentOu })}
             </div>
         );
 
@@ -411,6 +413,11 @@ OrgUnitTree.propTypes = {
     labelStyle: PropTypes.object,
 
     /**
+     * Custom component to render on labels
+     */
+    labelChildren: PropTypes.func,
+
+    /**
      * Custom styling for the labels of selected OUs
      */
     selectedLabelStyle: PropTypes.object,
@@ -455,6 +462,7 @@ OrgUnitTree.defaultProps = {
     currentRoot: undefined,
     onChildrenLoaded: undefined,
     labelStyle: {},
+    labelChildren: null,
     selectedLabelStyle: {},
     typeInput: undefined,
     selectOnClick: false,

--- a/src/org-unit-tree/OrgUnitTree.component.js
+++ b/src/org-unit-tree/OrgUnitTree.component.js
@@ -90,21 +90,27 @@ class OrgUnitTree extends React.Component {
             this.setState({ loading: true });
 
             const childrenIds = root.children.map(({ id }) => id);
-            const extraFields = _(onChildrenLoaded.fields || [])
-                .map(field => [field, true])
-                .fromPairs()
-                .value();
 
-            const fields = {
-                id: true,
-                level: true,
-                displayName: true,
-                shortName: true,
-                children: true,
-                path: true,
-                parent: true,
-                ...extraFields,
-            };
+            const extraFields = onChildrenLoaded
+                ? _(onChildrenLoaded.fields || [])
+                      .map(field => [field, true])
+                      .fromPairs()
+                      .value()
+                : undefined;
+
+            const fields = Object.assign(
+                {},
+                {
+                    id: true,
+                    level: true,
+                    displayName: true,
+                    shortName: true,
+                    children: true,
+                    path: true,
+                    parent: true,
+                },
+                extraFields
+            );
 
             api.models.organisationUnits
                 .get({

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -45,6 +45,7 @@ export default class OrgUnitsSelector extends React.Component {
             fields: PropTypes.arrayOf(PropTypes.string),
             fn: PropTypes.func,
         }),
+        disabled: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -65,6 +66,7 @@ export default class OrgUnitsSelector extends React.Component {
         selectableIds: undefined,
         showShortName: false,
         showNameSetting: false,
+        disabled: false,
     };
 
     static childContextTypes = {
@@ -324,6 +326,7 @@ export default class OrgUnitsSelector extends React.Component {
             selectOnClick,
             selectableIds,
             initiallyExpanded = roots.length > 1 ? [] : roots.map(ou => ou.path),
+            disabled,
         } = this.props;
         const { filterByLevel, filterByGroup, filterByProgram, selectAll } = controls;
 
@@ -389,6 +392,7 @@ export default class OrgUnitsSelector extends React.Component {
                                         selectOnClick={selectOnClick}
                                         selectableIds={selectableIds}
                                         useShortNames={useShortNames}
+                                        disabled={disabled}
                                     />
                                 </div>
                             ))}

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -24,6 +24,7 @@ export default class OrgUnitsSelector extends React.Component {
         levels: PropTypes.arrayOf(PropTypes.number),
         rootIds: PropTypes.arrayOf(PropTypes.string),
         listParams: PropTypes.object,
+        labelChildren: PropTypes.func,
         controls: PropTypes.shape({
             filterByLevel: PropTypes.bool,
             filterByGroup: PropTypes.bool,
@@ -48,6 +49,7 @@ export default class OrgUnitsSelector extends React.Component {
 
     static defaultProps = {
         levels: null,
+        labelChildren: null,
         controls: {
             filterByLevel: true,
             filterByGroup: true,
@@ -381,6 +383,7 @@ export default class OrgUnitsSelector extends React.Component {
                                                   }
                                                 : undefined
                                         }
+                                        labelChildren={this.props.labelChildren}
                                         hideCheckboxes={hideCheckboxes}
                                         hideMemberCount={hideMemberCount}
                                         selectOnClick={selectOnClick}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2377,6 +2377,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-dom@17.0.14":
+  version "17.0.14"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.14.tgz#c8f917156b652ddf807711f5becbd2ab018dea9f"
+  integrity sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-linkify@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/react-linkify/-/react-linkify-1.0.0.tgz#72278026e9f945ddf895c1e9c094353d8a680812"
@@ -2398,6 +2405,20 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/react@17.0.43":
+  version "17.0.43"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.43.tgz#4adc142887dd4a2601ce730bc56c3436fdb07a55"
+  integrity sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.23.0.tgz#0a6655b3e2708eaabca00b7372fafd7a792a7b09"
+  integrity sha512-YIoDCTH3Af6XM5VuwGG/QL/CJqga1Zm3NkU3HZ4ZHK2fRMPYP1VczsTUqtsf43PH/iJNVlPHAo2oWX7BSdB2Hw==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
### :pushpin: References

CLPC Facial reconstruction https://github.com/EyeSeeTea/emergency-responses-app/pull/70

### :memo: Implementation

- Added children slot for labels, in order to allow jsx next to the label
- Added disabled prop to disallow selecting an orgunit (for loading states where the component is used)

### :art: Screenshots

![image](https://github.com/user-attachments/assets/84c897c4-b68d-49bd-a25d-8c9b31caf10e)
_Added Chip tag as an example_

![image](https://github.com/user-attachments/assets/1686582e-01e2-41bd-9c05-8b39a866dd6d)
_Disabled state; it still allow expanding the tree, but not selecting any orgunit_

### :fire: Testing

`docker.eyeseetea.com/samaritans/dhis2-data:40.4.1-sp-ip-develop-est`

In EMR app, go to `http://localhost:8081/#/frr` and select 'Responses Configuration'. If you don't see anything or it says you are not in the user group, you should add your user to the needed user groups. If you don't have user, ask to project manager.

![image](https://github.com/user-attachments/assets/7e42c6a5-7458-4f78-856a-12d370043770)

On 'Responses configuration' you will see the orgunit tree. If you select a country and later click on 'Create response for country level' and confirm the dialog, you will see the disabled state while the request outside is loading. Check video media on the attached PR if needed.