### PR TITLE
[Objects Table] Add optional prop alignment to table + columns props

### DIFF
--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -106,6 +106,7 @@ export interface DataTableProps<T extends ReferenceObject> {
     onReorderColumns?(columns: Array<keyof T>): void;
     customClasses?: CustomClassesType;
     stickyHeader?: boolean;
+    columnsAlignment?: "left" | "center" | "right";
 }
 
 export function DataTable<T extends ReferenceObject = TableObject>(props: DataTableProps<T>) {
@@ -297,6 +298,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
                             hideColumnVisibilityOptions={hideColumnVisibilityOptions}
                             hideSelectAll={hideSelectAll}
                             allowReorderingColumns={allowReorderingColumns}
+                            alignment={props.columnsAlignment}
                         />
                         <DataTableBody
                             rows={rowObjects}
@@ -312,6 +314,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
                             enableMultipleAction={enableMultipleAction}
                             loading={loading}
                             childrenKeys={childrenKeys}
+                            alignment={props.columnsAlignment}
                         />
                     </Table>
                 </Paper>

--- a/src/data-table/DataTableBody.tsx
+++ b/src/data-table/DataTableBody.tsx
@@ -12,6 +12,7 @@ import _ from "lodash";
 import React, { MouseEvent, useState } from "react";
 import i18n from "../utils/i18n";
 import {
+    Alignment,
     MouseActionMapping,
     MouseActionsMapping,
     ReferenceObject,
@@ -69,6 +70,7 @@ export interface DataTableBodyProps<T extends ReferenceObject> {
     loading?: boolean;
     childrenKeys?: string[];
     mouseActionsMapping?: MouseActionsMapping;
+    alignment?: Alignment;
 }
 
 export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyProps<T>) {
@@ -212,7 +214,7 @@ export function DataTableBody<T extends ReferenceObject>(props: DataTableBodyPro
                         <TableCell
                             key={`${labelId}-column-${column.name}`}
                             scope="row"
-                            align="left"
+                            align={props.alignment || column.alignment || "left"}
                             style={cellStyle}
                         >
                             {formatRowValue(column, row)}

--- a/src/data-table/DataTableHeader.tsx
+++ b/src/data-table/DataTableHeader.tsx
@@ -15,6 +15,7 @@ import ColumnSelectorDialog from "./ColumnSelectorDialog";
 import { ContextualMenu } from "./ContextualMenu";
 import { DataTableNotifications } from "./DataTableNotifications";
 import {
+    Alignment,
     ReferenceObject,
     TableColumn,
     TableGlobalAction,
@@ -59,6 +60,7 @@ export interface DataTableHeaderProps<T extends ReferenceObject> {
     hideColumnVisibilityOptions?: boolean;
     hideSelectAll?: boolean;
     allowReorderingColumns?: boolean;
+    alignment?: Alignment;
 }
 
 export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeaderProps<T>) {
@@ -139,7 +141,7 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
                         return (
                             <TableCell
                                 key={`data-table-cell-${column.name}`}
-                                align="left"
+                                align={props.alignment || column.alignment || "left"}
                                 sortDirection={
                                     field === column.name && column.sortable ? order : false
                                 }

--- a/src/data-table/types.ts
+++ b/src/data-table/types.ts
@@ -13,7 +13,10 @@ export interface TableColumn<T extends ReferenceObject> {
     sortable?: boolean;
     hidden?: boolean;
     getValue?(row: T, defaultValue: ReactNode): ReactNode;
+    alignment?: Alignment;
 }
+
+export type Alignment = "left" | "center" | "right";
 
 export interface TableAction<T extends ReferenceObject> {
     name: string;


### PR DESCRIPTION
Required by https://app.clickup.com/t/86968nh51

Alignment of header and data cells was hardcoded to "left". 

Added 2 props, one at the table level (columnsAlignment) and other for each column (alignment). Values: `"left" | "center" | "right"`.  All props are optional. Default value is `left` so the rendering of existing tables does not change.