### PR TITLE
Feature/object table custom config

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.11.0",
+    "version": "2.12.0-beta.1",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/data-table/ContextualMenu.tsx
+++ b/src/data-table/ContextualMenu.tsx
@@ -34,11 +34,21 @@ export interface ContextualMenuProps<T extends ReferenceObject> {
     onClose(): void;
     actions: TableAction<T>[];
     selection: TableSelection[];
+    customConfig?: React.ReactNode;
 }
 
 export function ContextualMenu<T extends ReferenceObject>(props: ContextualMenuProps<T>) {
     const classes = useStyles();
-    const { isOpen, rows, positionLeft, positionTop, onClose, actions, selection } = props;
+    const {
+        isOpen,
+        rows,
+        positionLeft,
+        positionTop,
+        onClose,
+        actions,
+        selection,
+        customConfig,
+    } = props;
 
     const handleActionClick = (action: TableAction<T>) => {
         return () => {
@@ -80,6 +90,7 @@ export function ContextualMenu<T extends ReferenceObject>(props: ContextualMenuP
                     </Typography>
                 </MenuItem>
             ))}
+            {customConfig}
         </Menu>
     );
 }

--- a/src/data-table/ContextualMenu.tsx
+++ b/src/data-table/ContextualMenu.tsx
@@ -34,7 +34,7 @@ export interface ContextualMenuProps<T extends ReferenceObject> {
     onClose(): void;
     actions: TableAction<T>[];
     selection: TableSelection[];
-    customConfig?: React.ReactNode;
+    globalActionComponents?: React.ReactNode;
 }
 
 export function ContextualMenu<T extends ReferenceObject>(props: ContextualMenuProps<T>) {
@@ -47,7 +47,7 @@ export function ContextualMenu<T extends ReferenceObject>(props: ContextualMenuP
         onClose,
         actions,
         selection,
-        customConfig,
+        globalActionComponents,
     } = props;
 
     const handleActionClick = (action: TableAction<T>) => {
@@ -90,7 +90,7 @@ export function ContextualMenu<T extends ReferenceObject>(props: ContextualMenuP
                     </Typography>
                 </MenuItem>
             ))}
-            {customConfig}
+            {globalActionComponents}
         </Menu>
     );
 }

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -107,7 +107,7 @@ export interface DataTableProps<T extends ReferenceObject> {
     customClasses?: CustomClassesType;
     stickyHeader?: boolean;
     columnsAlignment?: "left" | "center" | "right";
-    customConfig?: React.ReactNode;
+    globalActionComponents?: React.ReactNode;
     childrenTransfer?: React.ReactNode;
     keepDisabledColumns?: boolean;
 }
@@ -143,7 +143,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
         selectionMessages: overrideSelectionMessages,
         allowReorderingColumns,
         onReorderColumns,
-        customConfig,
+        globalActionComponents,
         childrenTransfer,
         keepDisabledColumns = true,
     } = props;
@@ -305,7 +305,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
                             hideSelectAll={hideSelectAll}
                             allowReorderingColumns={allowReorderingColumns}
                             alignment={props.columnsAlignment}
-                            customConfig={customConfig}
+                            globalActionComponents={globalActionComponents}
                             childrenTransfer={childrenTransfer}
                             keepDisabledColumns={keepDisabledColumns}
                         />

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -107,6 +107,7 @@ export interface DataTableProps<T extends ReferenceObject> {
     customClasses?: CustomClassesType;
     stickyHeader?: boolean;
     columnsAlignment?: "left" | "center" | "right";
+    customConfig?: React.ReactNode;
 }
 
 export function DataTable<T extends ReferenceObject = TableObject>(props: DataTableProps<T>) {
@@ -140,6 +141,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
         selectionMessages: overrideSelectionMessages,
         allowReorderingColumns,
         onReorderColumns,
+        customConfig,
     } = props;
 
     const renderPosition = paginationOptions.renderPosition || defaultRenderPosition;
@@ -299,6 +301,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
                             hideSelectAll={hideSelectAll}
                             allowReorderingColumns={allowReorderingColumns}
                             alignment={props.columnsAlignment}
+                            customConfig={customConfig}
                         />
                         <DataTableBody
                             rows={rowObjects}

--- a/src/data-table/DataTableHeader.tsx
+++ b/src/data-table/DataTableHeader.tsx
@@ -61,6 +61,7 @@ export interface DataTableHeaderProps<T extends ReferenceObject> {
     hideSelectAll?: boolean;
     allowReorderingColumns?: boolean;
     alignment?: Alignment;
+    customConfig?: React.ReactNode;
 }
 
 export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeaderProps<T>) {
@@ -81,6 +82,7 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
         hideColumnVisibilityOptions = false,
         hideSelectAll = false,
         allowReorderingColumns,
+        customConfig,
     } = props;
 
     const { field, order } = sorting;
@@ -108,6 +110,8 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
             : undefined,
         ...globalActions,
     ]);
+
+    const showTableConfig = tableActions.length > 0 || Boolean(customConfig);
 
     const openTableActions = (event: MouseEvent<HTMLTableHeaderCellElement>) => {
         setContextMenuTarget([event.clientX, event.clientY + event.currentTarget.clientHeight / 2]);
@@ -160,7 +164,7 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
                         );
                     })}
                     <TableCell padding="none" align={"center"} onClick={openTableActions}>
-                        {tableActions.length > 0 && (
+                        {showTableConfig && (
                             <IconButton>
                                 <SettingsIcon />
                             </IconButton>
@@ -187,6 +191,7 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
                     selection={contextMenuRows}
                     actions={tableActions}
                     onClose={closeTableActions}
+                    customConfig={customConfig}
                 />
             )}
         </React.Fragment>

--- a/src/data-table/DataTableHeader.tsx
+++ b/src/data-table/DataTableHeader.tsx
@@ -61,7 +61,7 @@ export interface DataTableHeaderProps<T extends ReferenceObject> {
     hideSelectAll?: boolean;
     allowReorderingColumns?: boolean;
     alignment?: Alignment;
-    customConfig?: React.ReactNode;
+    globalActionComponents?: React.ReactNode;
     childrenTransfer?: React.ReactNode;
     keepDisabledColumns?: boolean;
 }
@@ -84,7 +84,7 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
         hideColumnVisibilityOptions = false,
         hideSelectAll = false,
         allowReorderingColumns,
-        customConfig,
+        globalActionComponents,
         childrenTransfer,
         keepDisabledColumns = true,
     } = props;
@@ -115,7 +115,7 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
         ...globalActions,
     ]);
 
-    const showTableConfig = tableActions.length > 0 || Boolean(customConfig);
+    const showTableConfig = tableActions.length > 0 || Boolean(globalActionComponents);
 
     const openTableActions = (event: MouseEvent<HTMLTableHeaderCellElement>) => {
         setContextMenuTarget([event.clientX, event.clientY + event.currentTarget.clientHeight / 2]);
@@ -197,7 +197,7 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
                     selection={contextMenuRows}
                     actions={tableActions}
                     onClose={closeTableActions}
-                    customConfig={customConfig}
+                    globalActionComponents={globalActionComponents}
                 />
             )}
         </React.Fragment>

--- a/src/data-table/ObjectsTable.tsx
+++ b/src/data-table/ObjectsTable.tsx
@@ -37,7 +37,7 @@ export interface ObjectsTableProps<T extends ReferenceObject> extends DataTableP
     onActionButtonClick?(event: MouseEvent<unknown>): void;
     actionButtonLabel?: ReactNode;
     className?: string;
-    customConfig?: React.ReactNode;
+    globalActionComponents?: React.ReactNode;
 }
 
 export function ObjectsTable<T extends ReferenceObject = TableObject>(props: ObjectsTableProps<T>) {

--- a/src/data-table/ObjectsTable.tsx
+++ b/src/data-table/ObjectsTable.tsx
@@ -37,6 +37,7 @@ export interface ObjectsTableProps<T extends ReferenceObject> extends DataTableP
     onActionButtonClick?(event: MouseEvent<unknown>): void;
     actionButtonLabel?: ReactNode;
     className?: string;
+    customConfig?: React.ReactNode;
 }
 
 export function ObjectsTable<T extends ReferenceObject = TableObject>(props: ObjectsTableProps<T>) {

--- a/src/dropdown/Dropdown.tsx
+++ b/src/dropdown/Dropdown.tsx
@@ -47,7 +47,7 @@ export const Dropdown: React.FC<DropdownProps> = React.memo(props => {
             >
                 {!hideEmpty && <MenuItem value={""}>{i18n.t("<No value>")}</MenuItem>}
                 {items.map(item => (
-                    <MenuItem key={item.value} value={item.value}>
+                    <MenuItem key={item.value} value={item.value} disabled={item.disabled}>
                         {item.text}
                     </MenuItem>
                 ))}

--- a/src/dropdown/GenericDropdown.tsx
+++ b/src/dropdown/GenericDropdown.tsx
@@ -2,7 +2,11 @@ import { createTheme, FormControl, InputLabel, MuiThemeProvider } from "@materia
 import cyan from "@material-ui/core/colors/cyan";
 import React from "react";
 
-export type DropdownItem<Value extends string = string> = { value: Value; text: string };
+export type DropdownItem<Value extends string = string> = {
+    value: Value;
+    text: string;
+    disabled?: boolean;
+};
 
 export interface DropdownFormProps {
     className?: string;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869a4vv2h [Row and column configuration is missing](https://app.clickup.com/t/869atk4wy)

### :memo: Implementation
- add optional parameter to render custom config in object table menu

Additional:
- add disabled property in dropdown options (I copied the component in dataset-configuration to add the option to disable. I included the update here since it might be useful for others)

### :video_camera: Screenshots/Screen capture
**custom config component rendered in table actions**
<img width="808" height="443" alt="image" src="https://github.com/user-attachments/assets/6092de86-27d5-4e34-b9a7-a664ffb00830" />

**disabled dropdown options**
<img width="601" height="288" alt="image" src="https://github.com/user-attachments/assets/bc60420f-d62d-4c09-9aeb-39b2d2870234" />


### :fire: Notes to the tester
