### PR TITLE
avoid table without columns headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.12.0",
+    "version": "2.13.0-beta.1",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/data-table/ColumnSelectorDialog.tsx
+++ b/src/data-table/ColumnSelectorDialog.tsx
@@ -14,6 +14,7 @@ interface ColumnSelectorDialogProps<T extends ReferenceObject> {
     onCancel: () => void;
     childrenTransfer?: React.ReactNode;
     keepDisabledColumns?: boolean;
+    allowEmptyColumns?: boolean;
 }
 
 type TableColumnsType<T> = (keyof T)[];
@@ -31,6 +32,7 @@ export function ColumnSelectorDialog<T extends ReferenceObject>(
         onCancel,
         allowReorderingColumns = true,
         keepDisabledColumns = true,
+        allowEmptyColumns = false,
     } = props;
     const sortableColumns = columns.map(
         ({ name, text: label, disabled }): TransferOption => ({
@@ -55,10 +57,11 @@ export function ColumnSelectorDialog<T extends ReferenceObject>(
 
     const updateSelectedColumns = React.useCallback<UpdateSelectedColumns<T>>(
         ({ selected }) => {
+            if (!allowEmptyColumns && selected.length === 0) return;
             // selected is always an empty array if the internal "Remove All ⇍" button is clicked
             onChange(mergeWithDisabled(selected));
         },
-        [onChange, mergeWithDisabled]
+        [onChange, mergeWithDisabled, allowEmptyColumns]
     );
 
     return (

--- a/src/data-table/DataTable.tsx
+++ b/src/data-table/DataTable.tsx
@@ -110,6 +110,7 @@ export interface DataTableProps<T extends ReferenceObject> {
     globalActionComponents?: React.ReactNode;
     childrenTransfer?: React.ReactNode;
     keepDisabledColumns?: boolean;
+    allowEmptyColumns?: boolean;
 }
 
 export function DataTable<T extends ReferenceObject = TableObject>(props: DataTableProps<T>) {
@@ -146,6 +147,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
         globalActionComponents,
         childrenTransfer,
         keepDisabledColumns = true,
+        allowEmptyColumns = true,
     } = props;
 
     const renderPosition = paginationOptions.renderPosition || defaultRenderPosition;
@@ -308,6 +310,7 @@ export function DataTable<T extends ReferenceObject = TableObject>(props: DataTa
                             globalActionComponents={globalActionComponents}
                             childrenTransfer={childrenTransfer}
                             keepDisabledColumns={keepDisabledColumns}
+                            allowEmptyColumns={allowEmptyColumns}
                         />
                         <DataTableBody
                             rows={rowObjects}

--- a/src/data-table/DataTableHeader.tsx
+++ b/src/data-table/DataTableHeader.tsx
@@ -64,6 +64,7 @@ export interface DataTableHeaderProps<T extends ReferenceObject> {
     globalActionComponents?: React.ReactNode;
     childrenTransfer?: React.ReactNode;
     keepDisabledColumns?: boolean;
+    allowEmptyColumns: boolean;
 }
 
 export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeaderProps<T>) {
@@ -87,6 +88,7 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
         globalActionComponents,
         childrenTransfer,
         keepDisabledColumns = true,
+        allowEmptyColumns = true,
     } = props;
 
     const { field, order } = sorting;
@@ -136,6 +138,7 @@ export function DataTableHeader<T extends ReferenceObject>(props: DataTableHeade
                     allowReorderingColumns={allowReorderingColumns}
                     childrenTransfer={childrenTransfer}
                     keepDisabledColumns={keepDisabledColumns}
+                    allowEmptyColumns={allowEmptyColumns}
                 />
             )}
             <TableHead>


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869a15qpj

### :memo: Implementation

- [x] add `allowEmptyColumns` prop to preserve current functionality (not fully sure about this, should we just always avoid this?)
- [x] ignore the `onChange` event when all columns are removed

### :video_camera: Screenshots/Screen capture

**Current functionality -> allowEmptyColumns = true**

https://github.com/user-attachments/assets/467aa14e-e290-42da-a2db-cedb671eb570

**allowEmptyColumns = false**

https://github.com/user-attachments/assets/fd1b341d-3852-4d6a-a414-f22c03e6a273

### :fire: Notes to the tester

#869a15qpj