### PR TITLE
fix/Dropdown use generic types

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.12.0",
+    "version": "2.13.0-beta.2",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/dropdown/Dropdown.tsx
+++ b/src/dropdown/Dropdown.tsx
@@ -28,7 +28,7 @@ const SelectWrapper: React.FC<SelectProps> = React.memo(props => {
     );
 });
 
-export const DropdownInner = <Value extends string = string>(props: DropdownProps<Value>) => {
+const DropdownInner = <Value extends string = string>(props: DropdownProps<Value>) => {
     const { items, value, onChange, label, hideEmpty, className } = props;
 
     const selectValue =

--- a/src/dropdown/Dropdown.tsx
+++ b/src/dropdown/Dropdown.tsx
@@ -5,7 +5,7 @@ import { DropdownForm, DropdownItem } from "./GenericDropdown";
 
 export interface DropdownProps<Value extends string = string> {
     className?: string;
-    items: DropdownItem[];
+    items: DropdownItem<Value>[];
     onChange: (value: Value | undefined) => void;
     label?: string;
     value?: Value;
@@ -28,7 +28,7 @@ const SelectWrapper: React.FC<SelectProps> = React.memo(props => {
     );
 });
 
-export const Dropdown: React.FC<DropdownProps> = React.memo(props => {
+export const DropdownInner = <Value extends string = string>(props: DropdownProps<Value>) => {
     const { items, value, onChange, label, hideEmpty, className } = props;
 
     const selectValue =
@@ -39,7 +39,7 @@ export const Dropdown: React.FC<DropdownProps> = React.memo(props => {
             <Select
                 data-cy={label}
                 value={selectValue}
-                onChange={ev => onChange((ev.target.value as string) || undefined)}
+                onChange={ev => onChange((ev.target.value as Value) || undefined)}
                 MenuProps={{
                     getContentAnchorEl: null,
                     anchorOrigin: { vertical: "bottom", horizontal: "left" },
@@ -54,4 +54,8 @@ export const Dropdown: React.FC<DropdownProps> = React.memo(props => {
             </Select>
         </SelectWrapper>
     );
-});
+};
+
+export const Dropdown = React.memo(DropdownInner) as <Value extends string = string>(
+    props: DropdownProps<Value>
+) => JSX.Element;

--- a/src/dropdown/Dropdown.tsx
+++ b/src/dropdown/Dropdown.tsx
@@ -56,6 +56,4 @@ const DropdownInner = <Value extends string = string>(props: DropdownProps<Value
     );
 };
 
-export const Dropdown = React.memo(DropdownInner) as <Value extends string = string>(
-    props: DropdownProps<Value>
-) => JSX.Element;
+export const Dropdown = React.memo(DropdownInner) as typeof DropdownInner;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes: #869b2wa0d https://app.clickup.com/t/869b2wa0d

### :memo: Implementation
- Updated dropdown component to accept generic type. Props already support generic type for options and value. 

### :video_camera: Screenshots/Screen capture


### :fire: Notes to the tester

