### PR TITLE
only include org. units within the users scope in filter by level/group

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.12.0",
+    "version": "2.13.0-beta.5",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/org-unit-select/OrgUnitSelectByGroup.component.js
+++ b/src/org-unit-select/OrgUnitSelectByGroup.component.js
@@ -126,17 +126,24 @@ class OrgUnitSelectByGroup extends React.Component {
     componentDidMount() {
         const { api } = this.context;
         if (this.props.withinUserHierarchyInFilters) {
-            api.get("/organisationUnits/", {
-                paging: false,
-                fields: "id",
-                withinUserHierarchy: this.props.withinUserHierarchyInFilters,
-            })
+            this.setState({ loading: true });
+            api.models.organisationUnits
+                .get({
+                    paging: false,
+                    fields: { id: true },
+                    withinUserHierarchy: this.props.withinUserHierarchyInFilters,
+                })
                 .getData()
                 .then(response => {
-                    if (response.organisationUnits.length > 0) {
-                        const orgUnitIdsSet = new Set(response.organisationUnits.map(ou => ou.id));
+                    if (response.objects.length > 0) {
+                        const orgUnitIdsSet = new Set(response.objects.map(ou => ou.id));
                         this.setState({ orgUnitsInHierarchy: orgUnitIdsSet });
                     }
+                    this.setState({ loading: false });
+                })
+                .catch(err => {
+                    console.error(`OrgUnitSelectByGroup: ${err.message}`);
+                    this.setState({ loading: false });
                 });
         }
     }

--- a/src/org-unit-select/OrgUnitSelectByGroup.component.js
+++ b/src/org-unit-select/OrgUnitSelectByGroup.component.js
@@ -23,6 +23,7 @@ class OrgUnitSelectByGroup extends React.Component {
             selection: undefined,
         };
         this.groupCache = {};
+        this.orgUnitsInHierarchy = undefined;
 
         this.addToSelection = addToSelection.bind(this);
         this.removeFromSelection = removeFromSelection.bind(this);
@@ -85,9 +86,17 @@ class OrgUnitSelectByGroup extends React.Component {
                                   levelsToFilter.includes(orgUnit.level)
                               )
                             : organisationUnits;
-                        this.groupCache[groupId] = filterOrgUnits;
+
                         // Make a copy of the returned array to ensure that the cache won't be modified from elsewhere
-                        resolve(filterOrgUnits);
+                        const excludeOrgUnits = this.state.orgUnitsInHierarchy
+                            ? filterOrgUnits.filter(orgUnit =>
+                                  this.state.orgUnitsInHierarchy.has(orgUnit.id)
+                              )
+                            : filterOrgUnits;
+
+                        this.groupCache[groupId] = excludeOrgUnits;
+
+                        resolve(excludeOrgUnits);
                     })
                     .catch(err => {
                         this.setState({ loading: false });
@@ -113,6 +122,24 @@ class OrgUnitSelectByGroup extends React.Component {
         // Material-UI SelectField will change height depending on whether or not it has a value
         return renderDropdown.call(this, menuItems, label);
     }
+
+    componentDidMount() {
+        const { api } = this.context;
+        if (this.props.withinUserHierarchyInFilters) {
+            api.get("/organisationUnits/", {
+                paging: false,
+                fields: "id",
+                withinUserHierarchy: this.props.withinUserHierarchyInFilters,
+            })
+                .getData()
+                .then(response => {
+                    if (response.organisationUnits.length > 0) {
+                        const orgUnitIdsSet = new Set(response.organisationUnits.map(ou => ou.id));
+                        this.setState({ orgUnitsInHierarchy: orgUnitIdsSet });
+                    }
+                });
+        }
+    }
 }
 
 OrgUnitSelectByGroup.propTypes = {
@@ -134,7 +161,7 @@ OrgUnitSelectByGroup.propTypes = {
     // If currentRoot is set, only org units that are descendants of the
     // current root org unit will be added to or removed from the selection
     currentRoot: PropTypes.object,
-
+    withinUserHierarchyInFilters: PropTypes.bool,
     // TODO: Add group cache prop?
 };
 

--- a/src/org-unit-select/OrgUnitSelectByLevel.component.js
+++ b/src/org-unit-select/OrgUnitSelectByLevel.component.js
@@ -67,7 +67,12 @@ class OrgUnitSelectByLevel extends React.Component {
                 this.setState({ loading: true });
 
                 api.models.organisationUnits
-                    .get({ paging: false, level, fields: { id: true, path: true } })
+                    .get({
+                        paging: false,
+                        level,
+                        fields: { id: true, path: true },
+                        withinUserHierarchy: this.props.withinUserHierarchyInFilters,
+                    })
                     .getData()
                     .then(({ objects }) => objects)
                     .then(orgUnitArray => {
@@ -147,7 +152,7 @@ OrgUnitSelectByLevel.propTypes = {
             }
         }
     },
-
+    withinUserHierarchyInFilters: PropTypes.bool,
     // TODO: Add level cache prop?
 };
 

--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -46,6 +46,7 @@ export default class OrgUnitsSelector extends React.Component {
             fn: PropTypes.func,
         }),
         disabled: PropTypes.bool,
+        withinUserHierarchyInFilters: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -67,6 +68,7 @@ export default class OrgUnitsSelector extends React.Component {
         showShortName: false,
         showNameSetting: false,
         disabled: false,
+        withinUserHierarchyInFilters: false,
     };
 
     static childContextTypes = {
@@ -327,6 +329,7 @@ export default class OrgUnitsSelector extends React.Component {
             selectableIds,
             initiallyExpanded = roots.length > 1 ? [] : roots.map(ou => ou.path),
             disabled,
+            withinUserHierarchyInFilters,
         } = this.props;
         const { filterByLevel, filterByGroup, filterByProgram, selectAll } = controls;
 
@@ -411,6 +414,9 @@ export default class OrgUnitsSelector extends React.Component {
                                                         levels={levels}
                                                         selected={selected}
                                                         currentRoot={currentRoot}
+                                                        withinUserHierarchyInFilters={
+                                                            withinUserHierarchyInFilters
+                                                        }
                                                         onUpdateSelection={
                                                             this.handleSelectionUpdate
                                                         }
@@ -432,6 +438,9 @@ export default class OrgUnitsSelector extends React.Component {
                                                         onItemSelection={this.changeOrgUnitGroup}
                                                         selectableIds={selectableIds}
                                                         selectableLevels={selectableLevels}
+                                                        withinUserHierarchyInFilters={
+                                                            withinUserHierarchyInFilters
+                                                        }
                                                     />
                                                 </div>
                                             )}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869b74ga4

### :memo: Implementation

added a new prop `withinUserHierarchyInFilters` to allow selection by level/group to only include org. units within the users scope (right now is including every org. unit in the selected level/group)

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/bf26d7af-6a81-4399-8b63-50f62efc1f4d

### :fire: Notes to the tester

can you please help me with a beta version so I can create the PR in dataset-configuration? @MiquelAdell 

#869b74ga4