### PR TITLE
apply withinUserHierarchy param to search

### DIFF
--- a/src/org-units-selector/OrgUnitsSelector.jsx
+++ b/src/org-units-selector/OrgUnitsSelector.jsx
@@ -143,7 +143,7 @@ export default class OrgUnitsSelector extends React.Component {
     }
 
     queryRoots({ search }) {
-        const { api, rootIds, listParams } = this.props;
+        const { api, rootIds, listParams, withinUserHierarchyInFilters } = this.props;
         const baseOptions = {
             fields: {
                 id: true,
@@ -162,6 +162,7 @@ export default class OrgUnitsSelector extends React.Component {
                 paging: true,
                 pageSize: 1000,
                 filter: { displayName: { ilike: search } },
+                ...(withinUserHierarchyInFilters ? { withinUserHierarchy: true } : {}),
             });
         } else if (rootIds) {
             let cancel = false;


### PR DESCRIPTION
Needed for: https://app.clickup.com/t/869b5yvxv #869b5yvxv

Updates the `OrgUnitSelector`. If the prop `withinUserHierarchyInFilters` is true, then the `withinUserHierarchy` param will be used to query org units during search. 

`withinUserHierarchyInFilters` was being used for level/group filters, and this change also adds it for search. 