### PR TITLE
[feature]: Display selection count notifications in ObjectsTable

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-04-02T23:36:26.113Z\n"
-"PO-Revision-Date: 2025-04-02T23:36:26.113Z\n"
+"POT-Creation-Date: 2026-05-11T15:35:33.204Z\n"
+"PO-Revision-Date: 2026-05-11T15:35:33.204Z\n"
 
 msgid "Cancel"
 msgstr ""
@@ -108,6 +108,11 @@ msgstr ""
 
 msgid "Search by name"
 msgstr ""
+
+msgid "There are {{count}} items selected on this page."
+msgid_plural "There are {{count}} items selected on this page."
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "Select all"
 msgstr ""

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -110,9 +110,10 @@ msgid "Search by name"
 msgstr ""
 
 msgid "There is 1 item selected on this page."
-msgid_plural "There are {{count}} items selected on this page."
-msgstr[0] ""
-msgstr[1] ""
+msgstr ""
+
+msgid "There are {{count}} items selected on this page."
+msgstr ""
 
 msgid "Select all"
 msgstr ""

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -109,7 +109,7 @@ msgstr ""
 msgid "Search by name"
 msgstr ""
 
-msgid "There are {{count}} items selected on this page."
+msgid "There is 1 item selected on this page."
 msgid_plural "There are {{count}} items selected on this page."
 msgstr[0] ""
 msgstr[1] ""

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -112,11 +112,10 @@ msgstr ""
 msgid "Search by name"
 msgstr "Buscar por nombre"
 
-#, fuzzy
-msgid "There are {{count}} items selected on this page."
+msgid "There is 1 item selected on this page."
 msgid_plural "There are {{count}} items selected on this page."
-msgstr[0] "Hay {{total}} elementos seleccionados en todas las páginas."
-msgstr[1] "Hay {{total}} elementos seleccionados en todas las páginas."
+msgstr[0] "Hay 1 elemento seleccionado en esta página."
+msgstr[1] "Hay {{count}} elementos seleccionados en esta página."
 
 msgid "Select all"
 msgstr "Seleccionar todo"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2025-04-02T23:36:26.113Z\n"
+"POT-Creation-Date: 2026-05-11T13:37:53.288Z\n"
 "PO-Revision-Date: 2019-02-14T11:21:26.165Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -111,6 +111,12 @@ msgstr ""
 
 msgid "Search by name"
 msgstr "Buscar por nombre"
+
+#, fuzzy
+msgid "There are {{count}} items selected on this page."
+msgid_plural "There are {{count}} items selected on this page."
+msgstr[0] "Hay {{total}} elementos seleccionados en todas las páginas."
+msgstr[1] "Hay {{total}} elementos seleccionados en todas las páginas."
 
 msgid "Select all"
 msgstr "Seleccionar todo"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -113,9 +113,10 @@ msgid "Search by name"
 msgstr "Buscar por nombre"
 
 msgid "There is 1 item selected on this page."
-msgid_plural "There are {{count}} items selected on this page."
-msgstr[0] "Hay 1 elemento seleccionado en esta página."
-msgstr[1] "Hay {{count}} elementos seleccionados en esta página."
+msgstr "Hay 1 elemento seleccionado en esta página."
+
+msgid "There are {{count}} items selected on this page."
+msgstr "Hay {{count}} elementos seleccionados en esta página."
 
 msgid "Select all"
 msgstr "Seleccionar todo"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2025-04-02T23:36:26.113Z\n"
+"POT-Creation-Date: 2026-05-11T13:37:53.288Z\n"
 "PO-Revision-Date: 2019-02-14T11:21:26.165Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -111,6 +111,12 @@ msgstr ""
 
 msgid "Search by name"
 msgstr "Rechercher par nom"
+
+#, fuzzy
+msgid "There are {{count}} items selected on this page."
+msgid_plural "There are {{count}} items selected on this page."
+msgstr[0] "Il y a {{total}} éléments sélectionnés dans toutes les pages"
+msgstr[1] "Il y a {{total}} éléments sélectionnés dans toutes les pages"
 
 msgid "Select all"
 msgstr "Sélectionner tout"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -113,9 +113,10 @@ msgid "Search by name"
 msgstr "Rechercher par nom"
 
 msgid "There is 1 item selected on this page."
-msgid_plural "There are {{count}} items selected on this page."
-msgstr[0] "Il y a 1 élément sélectionné dans cette page."
-msgstr[1] "Il y a {{count}} éléments sélectionnés dans cette page."
+msgstr "Il y a 1 élément sélectionné dans cette page."
+
+msgid "There are {{count}} items selected on this page."
+msgstr "Il y a {{count}} éléments sélectionnés dans cette page."
 
 msgid "Select all"
 msgstr "Sélectionner tout"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -112,11 +112,10 @@ msgstr ""
 msgid "Search by name"
 msgstr "Rechercher par nom"
 
-#, fuzzy
-msgid "There are {{count}} items selected on this page."
+msgid "There is 1 item selected on this page."
 msgid_plural "There are {{count}} items selected on this page."
-msgstr[0] "Il y a {{total}} éléments sélectionnés dans toutes les pages"
-msgstr[1] "Il y a {{total}} éléments sélectionnés dans toutes les pages"
+msgstr[0] "Il y a 1 élément sélectionné dans cette page."
+msgstr[1] "Il y a {{count}} éléments sélectionnés dans cette page."
 
 msgid "Select all"
 msgstr "Sélectionner tout"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "version": "2.13.0-beta.6",
     "main": "index.js",
     "types": "index.d.ts",
+    "publishConfig": {
+        "access": "public"
+    },
     "peerDependencies": {
         "@material-ui/core": "4",
         "@material-ui/icons": "4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "git+https://github.com/eyeseetea/d2-ui-components.git"
     },
-    "version": "2.13.0-beta.5",
+    "version": "2.13.0-beta.6",
     "main": "index.js",
     "types": "index.d.ts",
     "peerDependencies": {

--- a/src/objects-list/objects-list-hooks.ts
+++ b/src/objects-list/objects-list-hooks.ts
@@ -13,6 +13,7 @@ import {
     TableState,
 } from "..";
 import i18n from "../utils/i18n";
+import { getSelectionMessages } from "../data-table/utils/selection";
 import { ObjectsListProps } from "./ObjectsList";
 import _ from "lodash";
 
@@ -160,21 +161,13 @@ export function useTableWithSelectionCount<T extends ReferenceObject>(
         const total = tableProps.pagination?.total ?? rows.length;
         const ids = tableProps.ids ?? [];
 
-        const selectionInOtherPages = _.differenceBy(selection, rows, "id");
-        const allSelectedInPage =
-            rows.length > 0 && _.differenceBy(rows, selection, "id").length === 0;
-        const multiplePagesAvailable = total > rows.length;
-        const selectAllImplemented = ids.length > 0;
-
-        const isSelectionCountVisible =
-            selection.length === total ||
-            selectionInOtherPages.length > 0 ||
-            (allSelectedInPage && multiplePagesAvailable && selectAllImplemented);
-        if (isSelectionCountVisible) return [];
+        const hasSelectionNotifications =
+            getSelectionMessages(rows, selection, total, ids, [], undefined).length > 0;
+        if (hasSelectionNotifications) return [];
 
         return [
             {
-                message: i18n.t("There are {{count}} items selected on this page.", {
+                message: i18n.t("There is 1 item selected on this page.", {
                     count: selection.length,
                 }),
                 link: i18n.t("Clear selection"),

--- a/src/objects-list/objects-list-hooks.ts
+++ b/src/objects-list/objects-list-hooks.ts
@@ -165,11 +165,15 @@ export function useTableWithSelectionCount<T extends ReferenceObject>(
             getSelectionMessages(rows, selection, total, ids, [], undefined).length > 0;
         if (hasSelectionNotifications) return [];
 
+        const count = selection.length;
+        const message =
+            count === 1
+                ? i18n.t("There is 1 item selected on this page.")
+                : i18n.t("There are {{count}} items selected on this page.", { count });
+
         return [
             {
-                message: i18n.t("There is 1 item selected on this page.", {
-                    count: selection.length,
-                }),
+                message,
                 link: i18n.t("Clear selection"),
                 newSelection: [],
             },

--- a/src/objects-list/objects-list-hooks.ts
+++ b/src/objects-list/objects-list-hooks.ts
@@ -6,6 +6,7 @@ import {
     ReferenceObject,
     TableAction,
     TableColumn,
+    TableNotification,
     TablePagination,
     TableSelection,
     TableSorting,
@@ -13,6 +14,7 @@ import {
 } from "..";
 import i18n from "../utils/i18n";
 import { ObjectsListProps } from "./ObjectsList";
+import _ from "lodash";
 
 export interface TableConfig<Obj extends ReferenceObject>
     extends Omit<
@@ -133,4 +135,53 @@ export function useObjectsTable<Obj extends ReferenceObject>(
         initialState,
         ids: state.ids,
     };
+}
+
+export function useTableWithSelectionCount<T extends ReferenceObject>(
+    config: TableConfig<T>,
+    getRows: GetRows<T>,
+    getAllIds?: GetAllIds<T>
+): ObjectsListProps<T> {
+    const tableProps = useObjectsTable(config, getRows, getAllIds);
+    const [selection, setSelection] = useState<TableSelection[]>([]);
+
+    const onChange = useCallback(
+        (newState: TableState<T>) => {
+            setSelection(newState.selection ?? []);
+            tableProps.onChange(newState);
+        },
+        [tableProps]
+    );
+
+    const tableNotifications = useMemo<TableNotification[]>(() => {
+        if (selection.length === 0) return [];
+
+        const rows = tableProps.rows;
+        const total = tableProps.pagination?.total ?? rows.length;
+        const ids = tableProps.ids ?? [];
+
+        const selectionInOtherPages = _.differenceBy(selection, rows, "id");
+        const allSelectedInPage =
+            rows.length > 0 && _.differenceBy(rows, selection, "id").length === 0;
+        const multiplePagesAvailable = total > rows.length;
+        const selectAllImplemented = ids.length > 0;
+
+        const isSelectionCountVisible =
+            selection.length === total ||
+            selectionInOtherPages.length > 0 ||
+            (allSelectedInPage && multiplePagesAvailable && selectAllImplemented);
+        if (isSelectionCountVisible) return [];
+
+        return [
+            {
+                message: i18n.t("There are {{count}} items selected on this page.", {
+                    count: selection.length,
+                }),
+                link: i18n.t("Clear selection"),
+                newSelection: [],
+            },
+        ];
+    }, [selection, tableProps.rows, tableProps.pagination, tableProps.ids]);
+
+    return { ...tableProps, onChange, tableNotifications };
 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes:  https://app.clickup.com/t/869cqxtfn

### :memo: Implementation
 The d2-ui-components selection banner is only triggered when items are selected on *other* pages, so a user selecting rows on the current page gets no visual feedback before applying a bulk action.

  - Added `useTableWithSelectionCount` hook that wraps `useObjectsTable`
  - When items are selected only on the current page (and the existing banner would not appear), a notification is shown: *"There are {{count}} items selected on this page."* with a *Clear selection* link
  - The hook suppresses this notification when the standard DataTable selection messages already apply (cross-page selection, all items selected, etc.)

Propagated from https://github.com/EyeSeeTea/user-extended-app/pull/344
  
### :video_camera: Screenshots/Screen capture


### :fire: Notes to the tester

#869bryznd